### PR TITLE
feat: support running provena as a Python module

### DIFF
--- a/src/provena/__main__.py
+++ b/src/provena/__main__.py
@@ -1,0 +1,3 @@
+from provena.cli.main import cli
+
+cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import subprocess
+import sys
 import tempfile
 
 from click.testing import CliRunner
@@ -234,6 +236,15 @@ class TestCLIVersion:
         assert result.exit_code == 0
         assert "0.5.0" in result.output
 
+    def test_python_module_version(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "provena", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert "0.5.0" in result.stdout
 
 class TestCLIHelp:
     def test_help(self):


### PR DESCRIPTION
## Summary

Adds support for running Provena directly as a Python module using:

python -m provena

## Changes

- Added `src/provena/__main__.py` as the module entry point.
- Added a CLI test to verify `python -m provena --version` works correctly.

## Testing

- `ruff check .` passes successfully.
- The new `test_python_module_version` test passes.
- `tests/test_cli.py`: 20 passed, with 1 pre-existing unrelated failure in `test_audit_table_output` due to the expected "Audit Trail" text not being present in the current CLI output.
- Full test collection currently requires the optional `opentelemetry` dependency, which is not installed by the default development setup.

Closes #1