### PR TITLE
Add provenance and freshness query filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Provena are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `ContextTrail.query()` filters for exact provenance and freshness status values
+
 ## [0.5.0] - 2026-07-15
 
 ### Added

--- a/src/provena/storage.py
+++ b/src/provena/storage.py
@@ -51,6 +51,8 @@ class StorageBackend(Protocol):
         source: str | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
+        provenance_status: str | None = None,
+        freshness_status: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]: ...
     def add_annotation(
@@ -149,6 +151,8 @@ class SQLiteBackend:
         source: str | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
+        provenance_status: str | None = None,
+        freshness_status: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         clauses: list[str] = []
@@ -163,6 +167,12 @@ class SQLiteBackend:
         if end is not None:
             clauses.append("timestamp <= ?")
             params.append(end.isoformat())
+        if provenance_status is not None:
+            clauses.append("provenance_status = ?")
+            params.append(provenance_status)
+        if freshness_status is not None:
+            clauses.append("freshness_status = ?")
+            params.append(freshness_status)
 
         where = " AND ".join(clauses) if clauses else "1=1"
         sql = f"SELECT * FROM trail WHERE {where} ORDER BY id ASC LIMIT ?"
@@ -224,6 +234,8 @@ class InMemoryBackend:
         source: str | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
+        provenance_status: str | None = None,
+        freshness_status: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         with self._lock:
@@ -236,6 +248,18 @@ class InMemoryBackend:
         if end is not None:
             end_iso = end.isoformat()
             results = [r for r in results if r["timestamp"] <= end_iso]
+        if provenance_status is not None:
+            results = [
+                r
+                for r in results
+                if r.get("provenance_status", "MISSING") == provenance_status
+            ]
+        if freshness_status is not None:
+            results = [
+                r
+                for r in results
+                if r.get("freshness_status", "UNKNOWN") == freshness_status
+            ]
         return [{**r} for r in results[:limit]]
 
     def add_annotation(

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -367,10 +367,19 @@ class ContextTrail:
         source: ContextSource | str | None = None,
         start: datetime | None = None,
         end: datetime | None = None,
+        provenance_status: str | None = None,
+        freshness_status: str | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         source_str = source.value if isinstance(source, ContextSource) else source
-        return self._backend.query(source=source_str, start=start, end=end, limit=limit)
+        return self._backend.query(
+            source=source_str,
+            start=start,
+            end=end,
+            provenance_status=provenance_status,
+            freshness_status=freshness_status,
+            limit=limit,
+        )
 
     def annotate(
         self,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,6 +4,8 @@ import os
 import tempfile
 from datetime import datetime, timezone
 
+import pytest
+
 from provena.storage import SQLiteBackend
 
 
@@ -16,6 +18,7 @@ def _make_record(**overrides):
         "provenance_json": None,
         "provenance_status": "MISSING",
         "missing_fields": "source_url,created_at",
+        "freshness_status": "UNKNOWN",
         "chain_hash": "chain_abc",
         "previous_hash": "prev_abc",
         "config_hash": "",
@@ -25,6 +28,51 @@ def _make_record(**overrides):
     }
     base.update(overrides)
     return base
+
+
+@pytest.mark.parametrize("backend_fixture", ["memory_backend", "sqlite_backend"])
+def test_query_by_governance_status(request, backend_fixture):
+    backend = request.getfixturevalue(backend_fixture)
+    backend.append(
+        _make_record(
+            content_hash="missing-stale",
+            provenance_status="MISSING",
+            freshness_status="STALE",
+        )
+    )
+    backend.append(
+        _make_record(
+            content_hash="valid-fresh",
+            provenance_status="VALID",
+            freshness_status="FRESH",
+        )
+    )
+    backend.append(
+        _make_record(
+            content_hash="missing-fresh",
+            provenance_status="MISSING",
+            freshness_status="FRESH",
+        )
+    )
+
+    missing = backend.query(provenance_status="MISSING")
+    assert [record["content_hash"] for record in missing] == [
+        "missing-stale",
+        "missing-fresh",
+    ]
+
+    fresh = backend.query(freshness_status="FRESH")
+    assert [record["content_hash"] for record in fresh] == [
+        "valid-fresh",
+        "missing-fresh",
+    ]
+
+    combined = backend.query(
+        provenance_status="MISSING", freshness_status="FRESH", limit=1
+    )
+    assert [record["content_hash"] for record in combined] == ["missing-fresh"]
+
+    assert backend.query(provenance_status="missing") == []
 
 
 class TestInMemoryBackend:

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -278,6 +278,25 @@ class TestContextTrailQuery:
         results = memory_trail.query(limit=3)
         assert len(results) == 3
 
+    def test_query_by_governance_status(self, memory_trail):
+        memory_trail.log("missing", source="retriever")
+        memory_trail.log(
+            "valid and fresh",
+            source="retriever",
+            provenance=ProvenanceMetadata(
+                source_url="https://example.com",
+                created_at=datetime.now(timezone.utc),
+            ),
+        )
+
+        missing = memory_trail.query(provenance_status="MISSING")
+        assert len(missing) == 1
+        assert missing[0]["provenance_status"] == "MISSING"
+
+        fresh = memory_trail.query(freshness_status="FRESH")
+        assert len(fresh) == 1
+        assert fresh[0]["freshness_status"] == "FRESH"
+
 
 class TestContextTrailAnnotate:
     def test_annotate_record(self, memory_trail):


### PR DESCRIPTION
## What does this PR do?

Adds optional `provenance_status` and `freshness_status` filters to `ContextTrail.query()` and the storage backend contract.

- applies exact status matching consistently in SQLite and in-memory storage
- binds SQLite filter values as query parameters
- applies status filters before `limit`, including when both filters are combined
- preserves existing source and date-range filtering behavior
- documents the new public query capability in the changelog

Status matching intentionally uses the exact uppercase values stored by Provena, such as `MISSING`, `VALID`, `FRESH`, and `STALE`. Lowercase, mixed-case, and unknown strings return no records. CLI audit flags remain out of scope for this PR, following the maintainer's direction.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

## Testing

- `pytest tests/test_storage.py tests/test_trail.py -q` - 69 passed
- `pytest --cov=provena` - 226 passed, 5 optional-integration tests skipped, 88% coverage
- `ruff check src/ tests/` - passed
- `ruff format --check src/ tests/` - 27 files already formatted
- `mypy src/provena/` - no issues in 16 source files

## Related Issues

Fixes #13
