### PR TITLE
feat: add CSV export support

### DIFF
--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -105,7 +105,7 @@ def verify(ctx: click.Context) -> None:
     "--format",
     "fmt",
     default="json",
-   type=click.Choice(["json", "text", "csv"]),
+    type=click.Choice(["json", "text", "csv"]),
     help="Output format.",
 )
 @click.option("--output", "-o", default=None, type=click.Path(), help="Write to file.")

--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -105,7 +105,7 @@ def verify(ctx: click.Context) -> None:
     "--format",
     "fmt",
     default="json",
-    type=click.Choice(["json", "text"]),
+   type=click.Choice(["json", "text", "csv"]),
     help="Output format.",
 )
 @click.option("--output", "-o", default=None, type=click.Path(), help="Write to file.")
@@ -140,6 +140,8 @@ def report(ctx: click.Context, fmt: str, output: str | None) -> None:
 
         if fmt == "json":
             content = json.dumps(report_data, indent=2)
+        elif fmt == "csv":
+            content = trail.export(format="csv")
         else:
             content = _format_text_report(report_data)
 

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import csv
 import functools
 import inspect
+import io
 import json
 import logging
 import os
@@ -417,8 +419,30 @@ class ContextTrail:
 
     def export(self, format: str = "json") -> str:
         records = self._backend.all_records()
+
         if format == "json":
             return json.dumps(records, indent=2, default=str)
+
+        if format == "csv":
+            output = io.StringIO()
+            fieldnames = [
+                "id",
+                "timestamp",
+                "source",
+                "source_name",
+                "content_hash",
+                "provenance_status",
+                "freshness_status",
+                "chain_hash",
+            ]
+            writer = csv.writer(output)
+            writer.writerow(fieldnames)
+
+            for record in records:
+                writer.writerow([record.get(field, "") for field in fieldnames])
+
+            return output.getvalue()
+
         return json.dumps(records, default=str)
 
     def health(self) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,7 @@ class TestCLIReport:
         result = runner.invoke(cli, ["--db", "/nonexistent/path.db", "report"])
         assert result.exit_code != 0
 
+
 class TestCLISummary:
     def test_summary(self):
         db_path = _create_trail_db()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,11 +192,41 @@ class TestCLIReport:
             os.unlink(db_path)
             os.unlink(out_path)
 
+    def test_report_csv_to_file(self):
+        db_path = _create_trail_db()
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            out_path = f.name
+
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "report",
+                    "--format",
+                    "csv",
+                    "--output",
+                    out_path,
+                ],
+            )
+            assert result.exit_code == 0
+            assert "written to" in result.output
+
+            with open(out_path) as f:
+                content = f.read()
+
+            assert "id,timestamp,source,source_name,content_hash" in content
+            assert "src_0" in content
+        finally:
+            os.unlink(db_path)
+            os.unlink(out_path)
+
     def test_report_missing_db(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["--db", "/nonexistent/path.db", "report"])
         assert result.exit_code != 0
-
 
 class TestCLISummary:
     def test_summary(self):

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
 import json
 import os
 import sqlite3
@@ -343,7 +345,6 @@ class TestContextTrailHealth:
         h = memory_trail.health()
         assert h["record_count"] == 1
 
-
 class TestContextTrailExport:
     def test_export_json(self, memory_trail):
         memory_trail.log("test", source="retriever")
@@ -351,6 +352,25 @@ class TestContextTrailExport:
         data = json.loads(exported)
         assert len(data) == 1
         assert data[0]["content_hash"]
+
+    def test_export_csv(self, memory_trail):
+        memory_trail.log("first", source="retriever", source_name="source_1")
+        memory_trail.log("second", source="tool:api", source_name="source_2")
+
+        exported = memory_trail.export(format="csv")
+        rows = list(csv.reader(io.StringIO(exported)))
+
+        assert rows[0] == [
+            "id",
+            "timestamp",
+            "source",
+            "source_name",
+            "content_hash",
+            "provenance_status",
+            "freshness_status",
+            "chain_hash",
+        ]
+        assert len(rows) == 3
 
 
 class TestContextTrailSigning:

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -345,6 +345,7 @@ class TestContextTrailHealth:
         h = memory_trail.health()
         assert h["record_count"] == 1
 
+
 class TestContextTrailExport:
     def test_export_json(self, memory_trail):
         memory_trail.log("test", source="retriever")


### PR DESCRIPTION
## Summary

Adds CSV export support for Provena audit trail data, making it easier to open audit records in Excel or use them with reporting tools.

## Changes

- Added CSV support to `ContextTrail.export()`.
- Added `csv` as an output format for the CLI `report` command.
- Added tests for CSV headers and row output.
- Added a CLI test for exporting reports to a CSV file.

## Testing

- `ruff check .` passes successfully.
- `tests/test_trail.py` and `tests/test_cli.py`: 68 tests passed.
- 1 pre-existing unrelated failure remains in `TestCLIAudit.test_audit_table_output`, where the test expects "Audit Trail" in plain table output.

Closes #14