### PR TITLE
feat: add date filters to audit CLI

### DIFF
--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -37,6 +37,20 @@ def cli(ctx: click.Context, db: str, signing_key: str | None) -> None:
 @click.option("--source", "-s", default=None, help="Filter by source type.")
 @click.option("--limit", "-n", default=20, type=int, help="Max records to show.")
 @click.option(
+    "--from",
+    "start",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    default=None,
+    help="Filter records from this date (YYYY-MM-DD).",
+)
+@click.option(
+    "--to",
+    "end",
+    type=click.DateTime(formats=["%Y-%m-%d"]),
+    default=None,
+    help="Filter records up to this date (YYYY-MM-DD).",
+)
+@click.option(
     "--format",
     "fmt",
     default="table",
@@ -44,7 +58,14 @@ def cli(ctx: click.Context, db: str, signing_key: str | None) -> None:
     help="Output format.",
 )
 @click.pass_context
-def audit(ctx: click.Context, source: str | None, limit: int, fmt: str) -> None:
+def audit(
+    ctx: click.Context,
+    source: str | None,
+    limit: int,
+    start: datetime | None,
+    end: datetime | None,
+    fmt: str,
+) -> None:
     """Query the context governance audit log."""
     db_path = ctx.obj["db"]
     if not os.path.exists(db_path):
@@ -54,7 +75,7 @@ def audit(ctx: click.Context, source: str | None, limit: int, fmt: str) -> None:
 
     trail = ContextTrail(storage_path=db_path, signing_key=ctx.obj.get("signing_key"))
     try:
-        records = trail.query(source=source, limit=limit)
+        records = trail.query(source=source, limit=limit, start=start, end=end)
 
         if not records:
             click.echo("No records found.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,86 @@ class TestCLIAudit:
         finally:
             os.unlink(db_path)
 
+    def test_audit_from_date(self):
+        db_path = _create_trail_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "audit",
+                    "--from",
+                    "2020-01-01",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 3
+        finally:
+            os.unlink(db_path)
+
+    def test_audit_to_date(self):
+        db_path = _create_trail_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "audit",
+                    "--to",
+                    "2020-01-01",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "No records found." in result.output
+        finally:
+            os.unlink(db_path)
+
+    def test_audit_date_range(self):
+        db_path = _create_trail_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "audit",
+                    "--from",
+                    "2020-01-01",
+                    "--to",
+                    "2030-01-01",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 3
+        finally:
+            os.unlink(db_path)
+
+    def test_audit_invalid_date(self):
+        db_path = _create_trail_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["--db", db_path, "audit", "--from", "not-a-date"],
+            )
+            assert result.exit_code != 0
+            assert "Invalid value for '--from'" in result.output
+        finally:
+            os.unlink(db_path)
+
     def test_audit_empty_db(self):
         db_path = _create_trail_db(0)
         try:


### PR DESCRIPTION
## Summary

Adds `--from` and `--to` date filters to the `audit` CLI command, allowing users to query audit trail records within a specific date range.

## Changes

- Added `--from` and `--to` options to the `audit` command.
- Used Click's `DateTime` type to parse dates in `YYYY-MM-DD` format.
- Passed the parsed dates to the existing `trail.query()` date range functionality.
- Added tests for `--from`, `--to`, combined date ranges, and invalid date input.

## Testing

- `ruff check .` passes successfully.
- `ruff format --check src/ tests/` passes successfully.
- Relevant test suite: 72 tests passed.
- 1 pre-existing unrelated failure remains in `TestCLIAudit.test_audit_table_output`, where the test expects "Audit Trail" in plain table output.

Closes #12