### PR TITLE
test: verify signed chain rejects the wrong signing key (closes #21)

### DIFF
--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -114,6 +114,27 @@ class TestContextTrailVerify:
         finally:
             os.unlink(db_path)
 
+    def test_verify_signed_chain_rejects_wrong_key(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        try:
+            trail_a = ContextTrail(storage_path=db_path, signing_key="key-a")
+            for i in range(5):
+                trail_a.log(f"entry_{i}", source="retriever")
+
+            assert trail_a.verify_chain().intact
+            trail_a.close()
+
+            trail_b = ContextTrail(storage_path=db_path, signing_key="key-b")
+            verdict = trail_b.verify_chain()
+            assert not verdict.intact
+            assert verdict.total_records == 5
+            assert verdict.broken_at == 1
+            trail_b.close()
+        finally:
+            os.unlink(db_path)
+
 
 class TestContextTrailTrack:
     def test_track_sync_function(self, memory_trail):


### PR DESCRIPTION
Adds the missing end-to-end test from #21: an HMAC-signed trail must fail `verify_chain()` when opened with a mismatched key.

The new test (in `TestContextTrailVerify`, `tests/test_trail.py`):
1. Creates a `ContextTrail` on a temp SQLite DB with `signing_key="key-a"` and logs several entries; asserts the chain verifies intact with the correct key.
2. Opens a second `ContextTrail` on the same DB with `signing_key="key-b"`.
3. Asserts `verify_chain()` reports the chain broken — at record 1, since every keyed chain hash is recomputed with the wrong key (`ChainHasher.compute_chain_hash` uses HMAC-SHA256 over `previous:content:source:timestamp` when a key is set, so the first link mismatch is at the first record).

Follows the existing `test_verify_detects_tamper` pattern (tempfile DB, try/finally cleanup). No production code changes.