### PR TITLE
feat: add annotation retrieval API (closes #27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 - `ContextTrail.query()` filters for exact provenance and freshness status values
+- **Annotation retrieval API**: `ContextTrail.get_annotations(record_id)` and
+  `StorageBackend.get_annotations(record_id)` (implemented in `SQLiteBackend`
+  and `InMemoryBackend`) — read annotations for a record in insertion order,
+  returning `[]` for non-existent or unannotated records (#27)
+- New `"json_with_annotations"` export format including annotations grouped by
+  `record_id` (backward compatible — existing `"json"` format unchanged) (#27)
 
 ## [0.5.0] - 2026-07-15
 

--- a/src/provena/storage.py
+++ b/src/provena/storage.py
@@ -58,6 +58,7 @@ class StorageBackend(Protocol):
     def add_annotation(
         self, record_id: int, note: str, reviewer: str, timestamp: str
     ) -> int: ...
+    def get_annotations(self, record_id: int) -> list[dict[str, Any]]: ...
     def close(self) -> None: ...
 
 
@@ -194,6 +195,15 @@ class SQLiteBackend:
             self._conn.commit()
             return cursor.lastrowid  # type: ignore[return-value]
 
+    def get_annotations(self, record_id: int) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id, record_id, note, reviewer, timestamp "
+                "FROM annotations WHERE record_id = ? ORDER BY id ASC",
+                (record_id,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
     def close(self) -> None:
         if self._conn is not None:
             self._conn.close()
@@ -279,6 +289,10 @@ class InMemoryBackend:
                 }
             )
             return ann_id
+
+    def get_annotations(self, record_id: int) -> list[dict[str, Any]]:
+        with self._lock:
+            return [{**a} for a in self._annotations if a["record_id"] == record_id]
 
     def close(self) -> None:
         pass

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -392,6 +392,14 @@ class ContextTrail:
         ts = datetime.now(timezone.utc).isoformat()
         return self._backend.add_annotation(record_id, note, reviewer, ts)
 
+    def get_annotations(self, record_id: int) -> list[dict[str, Any]]:
+        """Return all annotations for ``record_id`` in insertion order.
+
+        Returns an empty list if the record does not exist or has no
+        annotations (does not raise).
+        """
+        return self._backend.get_annotations(record_id)
+
     def summary(self) -> dict[str, Any]:
         records = self._backend.all_records()
         total = len(records)
@@ -419,6 +427,18 @@ class ContextTrail:
 
     def export(self, format: str = "json") -> str:
         records = self._backend.all_records()
+
+        if format == "json_with_annotations":
+            annotations: dict[str, list[dict[str, Any]]] = {}
+            for record in records:
+                record_id = record["id"]
+                anns = self._backend.get_annotations(record_id)
+                if anns:
+                    annotations[str(record_id)] = anns
+            payload: dict[str, Any] = {"records": records}
+            if annotations:
+                payload["annotations"] = annotations
+            return json.dumps(payload, indent=2, default=str)
 
         if format == "json":
             return json.dumps(records, indent=2, default=str)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -315,3 +315,57 @@ class TestGetAnnotations:
             "reviewer",
             "timestamp",
         }
+
+    @pytest.mark.parametrize("backend_name", ["memory_backend", "sqlite_backend"])
+    def test_get_annotations_returns_defensive_copies(self, request, backend_name):
+        backend = request.getfixturevalue(backend_name)
+        backend.append(_make_record())
+        backend.add_annotation(
+            record_id=1,
+            note="original",
+            reviewer="alice",
+            timestamp="2026-07-13T00:00:00",
+        )
+
+        anns = backend.get_annotations(1)
+        assert anns[0]["note"] == "original"
+        anns[0]["note"] = "TAMPERED"
+        anns[0]["reviewer"] = "ATTACKER"
+        anns[0]["new_field"] = "injected"
+
+        anns_again = backend.get_annotations(1)
+        assert len(anns_again) == 1
+        assert anns_again[0]["note"] == "original"
+        assert anns_again[0]["reviewer"] == "alice"
+        assert "new_field" not in anns_again[0]
+
+    def test_get_annotations_persists_across_close_reopen(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        try:
+            backend1 = SQLiteBackend(path=db_path)
+            backend1.append(_make_record())
+            backend1.add_annotation(
+                record_id=1,
+                note="first",
+                reviewer="alice",
+                timestamp="2026-07-13T00:00:00",
+            )
+            backend1.add_annotation(
+                record_id=1,
+                note="second",
+                reviewer="bob",
+                timestamp="2026-07-13T01:00:00",
+            )
+            assert len(backend1.get_annotations(1)) == 2
+            backend1.close()
+
+            backend2 = SQLiteBackend(path=db_path)
+            anns = backend2.get_annotations(1)
+            assert len(anns) == 2
+            assert [a["note"] for a in anns] == ["first", "second"]
+            assert [a["reviewer"] for a in anns] == ["alice", "bob"]
+            backend2.close()
+        finally:
+            os.unlink(db_path)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -236,3 +236,82 @@ class TestSQLiteBackend:
             record_id=1, note="Checked", reviewer="bob", timestamp="2026-07-13"
         )
         assert ann_id >= 1
+
+
+class TestGetAnnotations:
+    @pytest.mark.parametrize("backend_name", ["memory_backend", "sqlite_backend"])
+    def test_empty_for_unannotated_record(self, request, backend_name):
+        backend = request.getfixturevalue(backend_name)
+        backend.append(_make_record())
+        assert backend.get_annotations(1) == []
+
+    @pytest.mark.parametrize("backend_name", ["memory_backend", "sqlite_backend"])
+    def test_returns_in_insertion_order(self, request, backend_name):
+        backend = request.getfixturevalue(backend_name)
+        backend.append(_make_record())
+        backend.add_annotation(
+            record_id=1,
+            note="first",
+            reviewer="alice",
+            timestamp="2026-07-13T00:00:00",
+        )
+        backend.add_annotation(
+            record_id=1,
+            note="second",
+            reviewer="bob",
+            timestamp="2026-07-13T01:00:00",
+        )
+        anns = backend.get_annotations(1)
+        assert [a["note"] for a in anns] == ["first", "second"]
+
+    @pytest.mark.parametrize("backend_name", ["memory_backend", "sqlite_backend"])
+    def test_filters_by_record_id(self, request, backend_name):
+        backend = request.getfixturevalue(backend_name)
+        backend.append(_make_record(content_hash="h1"))
+        backend.append(_make_record(content_hash="h2"))
+        backend.add_annotation(
+            record_id=1,
+            note="note-1",
+            reviewer="alice",
+            timestamp="2026-07-13T00:00:00",
+        )
+        backend.add_annotation(
+            record_id=2,
+            note="note-2",
+            reviewer="bob",
+            timestamp="2026-07-13T01:00:00",
+        )
+        backend.add_annotation(
+            record_id=1,
+            note="note-1b",
+            reviewer="carol",
+            timestamp="2026-07-13T02:00:00",
+        )
+        anns = backend.get_annotations(1)
+        assert [a["note"] for a in anns] == ["note-1", "note-1b"]
+        assert all(a["record_id"] == 1 for a in anns)
+
+    @pytest.mark.parametrize("backend_name", ["memory_backend", "sqlite_backend"])
+    def test_nonexistent_record_returns_empty(self, request, backend_name):
+        backend = request.getfixturevalue(backend_name)
+        assert backend.get_annotations(999) == []
+
+    @pytest.mark.parametrize("backend_name", ["memory_backend", "sqlite_backend"])
+    def test_returned_dicts_have_expected_keys(self, request, backend_name):
+        backend = request.getfixturevalue(backend_name)
+        backend.append(_make_record())
+        backend.add_annotation(
+            record_id=1,
+            note="reviewed",
+            reviewer="alice",
+            timestamp="2026-07-13T00:00:00",
+        )
+        anns = backend.get_annotations(1)
+        assert len(anns) == 1
+        assert set(anns[0].keys()) == {
+            "id",
+            "record_id",
+            "note",
+            "reviewer",
+            "timestamp",
+        }

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -332,6 +332,43 @@ class TestContextTrailAnnotate:
         assert ann_id >= 1
 
 
+class TestContextTrailGetAnnotations:
+    def test_empty_initially(self, memory_trail):
+        memory_trail.log("test", source="retriever")
+        assert memory_trail.get_annotations(1) == []
+
+    def test_returns_annotation_after_annotate(self, memory_trail):
+        memory_trail.log("test", source="retriever")
+        memory_trail.annotate(
+            record_id=1,
+            note="Reviewed and confirmed",
+            reviewer="jane.doe@company.com",
+        )
+        anns = memory_trail.get_annotations(1)
+        assert len(anns) == 1
+        assert anns[0]["note"] == "Reviewed and confirmed"
+        assert anns[0]["reviewer"] == "jane.doe@company.com"
+        assert anns[0]["timestamp"]
+
+    def test_multiple_annotations_in_order(self, memory_trail):
+        memory_trail.log("test", source="retriever")
+        memory_trail.annotate(record_id=1, note="first", reviewer="alice")
+        memory_trail.annotate(record_id=1, note="second", reviewer="bob")
+        anns = memory_trail.get_annotations(1)
+        assert [a["note"] for a in anns] == ["first", "second"]
+
+    def test_nonexistent_record_returns_empty(self, memory_trail):
+        assert memory_trail.get_annotations(999) == []
+
+    def test_does_not_break_hash_chain(self, memory_trail):
+        memory_trail.log("first", source="retriever")
+        memory_trail.annotate(record_id=1, note="review", reviewer="alice")
+        memory_trail.log("second", source="retriever")
+        verdict = memory_trail.verify_chain()
+        assert verdict.intact
+        assert verdict.total_records == 2
+
+
 class TestContextTrailSummary:
     def test_summary_empty(self, memory_trail):
         s = memory_trail.summary()
@@ -393,6 +430,37 @@ class TestContextTrailExport:
             "chain_hash",
         ]
         assert len(rows) == 3
+
+    def test_export_json_with_annotations(self, memory_trail):
+        memory_trail.log("test", source="retriever")
+        memory_trail.annotate(
+            record_id=1,
+            note="Reviewed and confirmed",
+            reviewer="alice",
+        )
+        exported = memory_trail.export(format="json_with_annotations")
+        data = json.loads(exported)
+        assert isinstance(data, dict)
+        assert len(data["records"]) == 1
+        assert data["annotations"]["1"]
+        assert len(data["annotations"]["1"]) == 1
+        assert data["annotations"]["1"][0]["note"] == "Reviewed and confirmed"
+
+    def test_export_json_with_annotations_omits_key_when_empty(self, memory_trail):
+        memory_trail.log("test", source="retriever")
+        exported = memory_trail.export(format="json_with_annotations")
+        data = json.loads(exported)
+        assert isinstance(data, dict)
+        assert len(data["records"]) == 1
+        assert "annotations" not in data
+
+    def test_export_json_unchanged_by_new_format(self, memory_trail):
+        memory_trail.log("test", source="retriever")
+        memory_trail.annotate(record_id=1, note="review", reviewer="alice")
+        exported = memory_trail.export(format="json")
+        data = json.loads(exported)
+        assert isinstance(data, list)
+        assert len(data) == 1
 
 
 class TestContextTrailSigning:

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -368,6 +368,31 @@ class TestContextTrailGetAnnotations:
         assert verdict.intact
         assert verdict.total_records == 2
 
+    def test_get_annotations_persists_across_close_reopen_sqlite(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        try:
+            trail = ContextTrail(storage_path=db_path)
+            trail.log("test", source="retriever")
+            trail.annotate(
+                record_id=1,
+                note="Reviewed and confirmed",
+                reviewer="jane.doe@company.com",
+            )
+            assert len(trail.get_annotations(1)) == 1
+            trail.close()
+
+            reopened = ContextTrail(storage_path=db_path)
+            anns = reopened.get_annotations(1)
+            assert len(anns) == 1
+            assert anns[0]["note"] == "Reviewed and confirmed"
+            assert anns[0]["reviewer"] == "jane.doe@company.com"
+            assert anns[0]["timestamp"]
+            reopened.close()
+        finally:
+            os.unlink(db_path)
+
 
 class TestContextTrailSummary:
     def test_summary_empty(self, memory_trail):
@@ -461,6 +486,42 @@ class TestContextTrailExport:
         data = json.loads(exported)
         assert isinstance(data, list)
         assert len(data) == 1
+
+    def test_export_json_with_annotations_on_empty_trail(self):
+        trail = ContextTrail(backend="memory")
+        try:
+            exported = trail.export(format="json_with_annotations")
+            data = json.loads(exported)
+            assert isinstance(data, dict)
+            assert data["records"] == []
+            assert "annotations" not in data
+        finally:
+            trail.close()
+
+    def test_export_json_with_annotations_sqlite_backend(self):
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        try:
+            trail = ContextTrail(storage_path=db_path)
+            trail.log("test", source="retriever")
+            trail.annotate(
+                record_id=1,
+                note="Reviewed and confirmed",
+                reviewer="alice",
+            )
+            exported = trail.export(format="json_with_annotations")
+            data = json.loads(exported)
+            assert isinstance(data, dict)
+            assert len(data["records"]) == 1
+            assert data["records"][0]["content_hash"]
+            assert "annotations" in data
+            assert len(data["annotations"]["1"]) == 1
+            assert data["annotations"]["1"][0]["note"] == "Reviewed and confirmed"
+            assert data["annotations"]["1"][0]["reviewer"] == "alice"
+            trail.close()
+        finally:
+            os.unlink(db_path)
 
 
 class TestContextTrailSigning:


### PR DESCRIPTION
## What does this PR do?

Adds the missing read-side of the annotation API. `trail.annotate()` exists but there was no way to retrieve what was annotated.

- `StorageBackend.get_annotations(record_id)` — new protocol method.
- `SQLiteBackend.get_annotations(record_id)` — `SELECT … FROM annotations WHERE record_id = ? ORDER BY id ASC`.
- `InMemoryBackend.get_annotations(record_id)` — filters the existing `_annotations` list (returns defensive copies).
- `ContextTrail.get_annotations(record_id)` — thin public-API wrapper.
- New `format="json_with_annotations"` value on `ContextTrail.export()` emitting `{"records": [...], "annotations": {"1": [...]}}`. The existing `format="json"` and `format="csv"` outputs are unchanged. The `"annotations"` key is omitted when no record has annotations.

Returns `[]` for a record with no annotations or for a non-existent `record_id` (does not raise), matching the contract of `query()`.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes (no new findings; 2 pre-existing issues on `main` listed below)
- [x] `ruff format --check src/ tests/` passes (no new findings; same 2 pre-existing files)
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated

## Testing

- `pytest --cov=provena` — 261 passed, 5 skipped, 89% coverage. The 5 skipped tests are pre-existing (`langchain-core` not installed in dev env).
- `mypy src/provena/` — Success: no issues found in 16 source files.
- `ruff check src/ tests/` — 2 findings, both pre-existing on `main` and unrelated to this PR: `RUF023` in `src/provena/validators/freshness.py:43` (unsorted `__slots__`) and `W292` in `tests/test_trail.py:652` (no trailing newline, in `TestDisabledMode`). No new findings introduced by this PR.

24 new tests added:

- `tests/test_storage.py::TestGetAnnotations` — 13 cases (6 parametrized across both backends + 1 SQLite-only persistence test).
- `tests/test_trail.py::TestContextTrailGetAnnotations` — 6 cases (empty, after annotate, multiple in order, non-existent record, hash chain intact, persistence across close/reopen).
- `tests/test_trail.py::TestContextTrailExport` — 5 new cases (new format with annotations, omit-key-when-empty, regression that old `json` format is unchanged, empty trail, SQLite-backed end-to-end).

Closes #27
