### PR TITLE
fix: avoid blocking event loop in OpenAI Agents hooks

### DIFF
--- a/src/provena/integrations/openai_agents.py
+++ b/src/provena/integrations/openai_agents.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from provena.models import ContextSource
@@ -37,7 +38,8 @@ try:
         ) -> None:
             tool_name = getattr(tool, "name", "unknown")
             agent_name = getattr(agent, "name", "unknown")
-            self._trail.log(
+            await asyncio.to_thread(
+                self._trail.log,
                 content=result,
                 source=ContextSource.TOOL,
                 source_name=f"openai:{tool_name}",
@@ -52,7 +54,8 @@ try:
         ) -> None:
             from_name = getattr(from_agent, "name", "unknown")
             to_name = getattr(to_agent, "name", "unknown")
-            self._trail.log(
+            await asyncio.to_thread(
+                self._trail.log,
                 content=f"Handoff from {from_name} to {to_name}",
                 source=ContextSource.AGENT,
                 source_name=f"openai:{from_name}",

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -5,8 +5,14 @@ All tests use mock objects so they run without the framework installed.
 
 from __future__ import annotations
 
+import asyncio
+import sys
+import threading
+from types import ModuleType, SimpleNamespace
+
 import pytest
 
+from provena.models import ContextSource
 from provena.trail import ContextTrail
 
 
@@ -151,6 +157,96 @@ try:
     _has_openai_agents = True
 except ImportError:
     pass
+
+
+@pytest.fixture
+def openai_run_hooks(monkeypatch):
+    module_name = "provena.integrations.openai_agents"
+    previous_module = sys.modules.pop(module_name, None)
+
+    agents_module = ModuleType("agents")
+    lifecycle_module = ModuleType("agents.lifecycle")
+
+    class MockRunHooks:
+        def __class_getitem__(cls, item):
+            return cls
+
+    agents_module.RunHooks = MockRunHooks
+    lifecycle_module.RunHooksContext = object
+    monkeypatch.setitem(sys.modules, "agents", agents_module)
+    monkeypatch.setitem(sys.modules, "agents.lifecycle", lifecycle_module)
+
+    from provena.integrations.openai_agents import ProvenaRunHooks
+
+    yield ProvenaRunHooks
+
+    sys.modules.pop(module_name, None)
+    if previous_module is not None:
+        sys.modules[module_name] = previous_module
+
+
+class BlockingTrail:
+    def __init__(self):
+        self.release = threading.Event()
+        self.calls = []
+
+    def log(self, **kwargs):
+        self.release.wait(timeout=0.5)
+        self.calls.append(kwargs)
+
+
+async def assert_hook_does_not_block(coroutine, trail, expected_call):
+    task = asyncio.create_task(coroutine)
+    await asyncio.sleep(0)
+
+    try:
+        assert not task.done(), "hook blocked the event loop until log() returned"
+    finally:
+        trail.release.set()
+        await task
+
+    assert trail.calls == [expected_call]
+
+
+class TestOpenAIAgentsHooks:
+    async def test_on_tool_end_does_not_block_event_loop(self, openai_run_hooks):
+        trail = BlockingTrail()
+        hook = openai_run_hooks(trail=trail)
+
+        await assert_hook_does_not_block(
+            hook.on_tool_end(
+                None,
+                SimpleNamespace(name="researcher"),
+                SimpleNamespace(name="web_search"),
+                "search results",
+            ),
+            trail,
+            {
+                "content": "search results",
+                "source": ContextSource.TOOL,
+                "source_name": "openai:web_search",
+                "metadata": {"agent": "researcher"},
+            },
+        )
+
+    async def test_on_handoff_does_not_block_event_loop(self, openai_run_hooks):
+        trail = BlockingTrail()
+        hook = openai_run_hooks(trail=trail)
+
+        await assert_hook_does_not_block(
+            hook.on_handoff(
+                None,
+                SimpleNamespace(name="researcher"),
+                SimpleNamespace(name="writer"),
+            ),
+            trail,
+            {
+                "content": "Handoff from researcher to writer",
+                "source": ContextSource.AGENT,
+                "source_name": "openai:researcher",
+                "metadata": {"to_agent": "writer"},
+            },
+        )
 
 
 class TestOpenAIAgentsImportError:


### PR DESCRIPTION
  ## What does this PR do?

  Offloads synchronous `ContextTrail.log()` calls to worker threads in the OpenAI Agents SDK adapter.

  Both `on_tool_end()` and `on_handoff()` now use `await asyncio.to_thread(...)`, allowing other coroutines to continue
  while logging is in progress. Existing log content, source names, and metadata are preserved.

  Regression tests verify that the event loop can make progress while `log()` is blocked.

  ## Checklist

  - [x] Tests added/updated for the change
  - [x] `ruff check src/ tests/` passes
  - [x] `ruff format --check src/ tests/` passes
  - [x] `mypy src/provena/` passes
  - [x] `pytest` passes with no failures
  - [ ] CHANGELOG.md updated (not required for this focused bug fix)

  ## Related Issues

Fixes #47