### PR TITLE
ContextTrail.export(format="xml") silently returns JSON with no warning or error. The user gets output in the wrong format with no indication.

### DIFF
--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -736,9 +736,9 @@ class ContextTrail:
 
         return json.dumps(records, default=str)
 
-    raise ValueError(
-        "Unsupported export format 'xml'. Use 'json', 'csv', or 'json_with_annotations'"
-    )
+        raise ValueError(
+            "Unsupported export format 'xml'. Use 'json', 'csv', or 'json_with_annotations'"
+        )
 
     def health(self) -> dict[str, Any]:
         """Return a health-check dictionary for the trail.

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -736,6 +736,10 @@ class ContextTrail:
 
         return json.dumps(records, default=str)
 
+    raise ValueError(
+        "Unsupported export format 'xml'. Use 'json', 'csv', or 'json_with_annotations'"
+    )
+
     def health(self) -> dict[str, Any]:
         """Return a health-check dictionary for the trail.
 


### PR DESCRIPTION
## What does this PR do?

<!-- In src/provena/trail.py, added a ValueError at the end of export() instead of the silent JSON fallback. List the supported formats in the error message.
So That if the user provides an unsupported format it raises a value error and display the supported formats -->

## Checklist

- [Yes ] Tests added/updated for the change
- [ All checks passed!] `ruff check src/ tests/` passes
- [48 files already formatted ] `ruff format --check src/ tests/` passes
- [Success: no issues found in 27 source files ] `mypy src/provena/` passes
- [13 test failed ] `pytest` passes with no failures
- [not needed ] CHANGELOG.md updated (if user-facing change)

## Related Issues

<!-- https://github.com/rajfirke/provena/issues/81: Fixes #123, Relates to #456 -->
