### PR TITLE
Raise ValueError for unsupported report formats

### DIFF
--- a/src/provena/report.py
+++ b/src/provena/report.py
@@ -32,7 +32,9 @@ def generate_report(
         return _render_text(data)
     if format == "pdf":
         return _render_pdf_string(data)
-    return json.dumps(data, indent=2, default=str)
+    raise ValueError(
+        f"Unsupported format '{format}'. Valid formats are: text, json, pdf."
+    )
 
 
 def generate_pdf_report(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -108,3 +108,9 @@ class TestReportEmpty:
         assert report["summary"]["total_records"] == 0
         assert report["compliance_score"] == 25
         trail.close()
+
+
+class TestReportInvalidFormats:
+    def test_invalid_format(self, trail_with_data):
+        with pytest.raises(ValueError, match="Unsupported format"):
+            generate_report(trail_with_data, format="html")


### PR DESCRIPTION
## What does this PR do?

<!-- A clear description of what this PR changes and why. -->
It fixes the report generator behaviour for unsupported formats.
Previously, passing an unsupported format would return a JSON report.
This PR instead changes that and raises a 'ValueError' with a message showing valid formats.
Along with that, a test was added to verify the invalid formats raise the expected error.

## Checklist

- [x] Tests added/updated for the change
- [ ] `ruff check src/ tests/` passes
- [ ] `ruff format --check src/ tests/` passes
- [ ] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [ ] CHANGELOG.md updated (if user-facing change)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
