### PR TITLE
Generate report fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to Provena are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **PDF Report Generation Bug** — Fixes an issue where generate_report(..., format="pdf")
+  returns the exact same plain text output as format="text".
+
 ## [1.0.0] - 2026-07-22
 
 ### Production Release

--- a/src/provena/report.py
+++ b/src/provena/report.py
@@ -56,15 +56,8 @@ def generate_pdf_report(
     Raises:
         ImportError: If ``fpdf2`` is not installed.
     """
-    try:
-        from fpdf import FPDF
-    except ImportError:
-        raise ImportError(
-            "fpdf2 is required for PDF reports. Install with: pip install provena[pdf]"
-        ) from None
-
     data = _collect_report_data(trail, title=title)
-    pdf = _build_pdf(data, FPDF)
+    pdf = _build_pdf(data, _load_fpdf())
     pdf.output(output_path)
     return output_path
 
@@ -88,7 +81,7 @@ def _collect_report_data(trail: Any, *, title: str = "") -> dict[str, Any]:
         checks_passed += 1
     else:
         issues.append(
-            f"Hash chain broken at record {verdict.broken_at} — "
+            f"Hash chain broken at record {verdict.broken_at} - "
             "tamper-evident logging compromised (Art. 12)"
         )
 
@@ -97,7 +90,7 @@ def _collect_report_data(trail: Any, *, title: str = "") -> dict[str, Any]:
     elif total > 0:
         pct = round(valid_count / total * 100)
         issues.append(
-            f"Only {pct}% of records have valid provenance — "
+            f"Only {pct}% of records have valid provenance - "
             "data lineage incomplete (Art. 10)"
         )
 
@@ -105,7 +98,7 @@ def _collect_report_data(trail: Any, *, title: str = "") -> dict[str, Any]:
         checks_passed += 1
     elif total > 0:
         issues.append(
-            f"{stale_count} stale records detected — "
+            f"{stale_count} stale records detected - "
             "context freshness monitoring needed"
         )
 
@@ -113,7 +106,7 @@ def _collect_report_data(trail: Any, *, title: str = "") -> dict[str, Any]:
         checks_passed += 1
     else:
         issues.append(
-            "Trail is not HMAC-signed — "
+            "Trail is not HMAC-signed - "
             "consider enabling signing for tamper resistance (Art. 12)"
         )
 
@@ -230,7 +223,20 @@ def _render_text(data: dict[str, Any]) -> str:
 
 
 def _render_pdf_string(data: dict[str, Any]) -> str:
-    return _render_text(data)
+    """
+    Helper function to generate a PDF compliance report and write it to stdout.
+
+    Args:
+        data: Data to be formatted into a pdf.
+
+    Returns:
+        Byte string to be outputted.
+
+    Raises:
+        ImportError: If ``fpdf2`` is not installed.
+    """
+    pdf = _build_pdf(data, _load_fpdf())
+    return str(bytes(pdf.output()))
 
 
 def _build_pdf(data: dict[str, Any], fpdf_class: type) -> Any:
@@ -317,3 +323,22 @@ def _build_pdf(data: dict[str, Any], fpdf_class: type) -> Any:
         )
 
     return pdf
+
+
+def _load_fpdf() -> Any:
+    """
+    Helper function to load FPDF and return an instance of it.
+
+    Returns:
+        FPDF instance.
+
+    Raises:
+        ImportError: If ``fpdf2`` is not installed.
+    """
+    try:
+        from fpdf import FPDF
+    except ImportError:
+        raise ImportError(
+            "fpdf2 is required for PDF reports. Install with: pip install provena[pdf]"
+        ) from None
+    return FPDF

--- a/src/provena/report.py
+++ b/src/provena/report.py
@@ -12,7 +12,7 @@ def generate_report(
     *,
     format: str = "json",
     title: str = "Provena Governance Compliance Report",
-) -> str:
+) -> str | bytes:
     """Generate a compliance report from a ContextTrail.
 
     Args:
@@ -22,7 +22,7 @@ def generate_report(
 
     Returns:
         The report content as a string. For PDF, returns the raw bytes
-        as a string (use ``generate_pdf_report`` for file output).
+        as output.
     """
     data = _collect_report_data(trail, title=title)
 
@@ -222,7 +222,7 @@ def _render_text(data: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _render_pdf_string(data: dict[str, Any]) -> str:
+def _render_pdf_string(data: dict[str, Any]) -> bytes:
     """
     Helper function to generate a PDF compliance report and write it to stdout.
 
@@ -236,7 +236,7 @@ def _render_pdf_string(data: dict[str, Any]) -> str:
         ImportError: If ``fpdf2`` is not installed.
     """
     pdf = _build_pdf(data, _load_fpdf())
-    return str(bytes(pdf.output()))
+    return bytes(pdf.output())
 
 
 def _build_pdf(data: dict[str, Any], fpdf_class: type) -> Any:

--- a/src/provena/report.py
+++ b/src/provena/report.py
@@ -327,10 +327,10 @@ def _build_pdf(data: dict[str, Any], fpdf_class: type) -> Any:
 
 def _load_fpdf() -> Any:
     """
-    Helper function to load FPDF and return an instance of it.
+    Helper function to load and return the FPDF class.
 
     Returns:
-        FPDF instance.
+        FPDF class.
 
     Raises:
         ImportError: If ``fpdf2`` is not installed.

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -98,7 +98,7 @@ class TestReportPDF:
 
     def test_pdf_string_fallback(self, trail_with_data):
         report = generate_report(trail_with_data, format="pdf")
-        assert "COMPLIANCE SCORE" in report
+        assert "%PDF-" in report
 
 
 class TestReportEmpty:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -98,7 +98,7 @@ class TestReportPDF:
 
     def test_pdf_string_fallback(self, trail_with_data):
         report = generate_report(trail_with_data, format="pdf")
-        assert "%PDF-" in report
+        assert b"%PDF-" in report
 
 
 class TestReportEmpty:


### PR DESCRIPTION
## What does this PR do?

Patched generate_report bug for pdf format argument. I decided to go with the change of replacing any unicode characters found with ones that could fit in the latin-1 encoding as that is all FPDF supports along with shifting some functionality for importing FPDF to its own function since it would have to be used twice. I also decided on using `_build_pdf` since `_render_pdf_string` receives data and not a trial.

### report.py

- Added new `_load_fpdf` helper function to load an instance of fpdf.
- Changed the em-dashes in the `_collect_report_data` helper function to normal dashes.
- Changed `_render_pdf_string` to use `_build_pdf` instead of `_render_text`.

### test_report.py

- Changed the comparison to find the PDF file header in the byte string.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

## Related Issues

This is in response to issue #92 
