### PR TITLE
fix(policy): log warning for unknown check names in PolicyEngine.from…

### DIFF
--- a/src/provena/policy.py
+++ b/src/provena/policy.py
@@ -182,6 +182,12 @@ class PolicyEngine:
                 policies.append(
                     source_allowlist(allowed=allowed, enforcement=enforcement)
                 )
+            else:
+                _logger.warning(
+                    "Unknown policy check %r — skipping. "
+                    "Valid checks: freshness, provenance, require_signing, source_allowlist",
+                    check_name,
+                )
 
         return cls(policies)
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -220,10 +221,13 @@ class TestPolicyEngineFromConfig:
         engine = PolicyEngine.from_config(config)
         assert engine.policies[0].enforcement == EnforcementLevel.LOG
 
-    def test_unknown_check_ignored(self):
+    def test_unknown_check_ignored(self, caplog):
         config = [{"check": "nonexistent"}]
-        engine = PolicyEngine.from_config(config)
+        with caplog.at_level(logging.WARNING, logger="provena.policy"):
+            engine = PolicyEngine.from_config(config)
         assert len(engine.policies) == 0
+        assert any("Unknown policy check" in msg for msg in caplog.messages)
+        assert any("nonexistent" in msg for msg in caplog.messages)
 
 
 class TestBuiltInPolicies:


### PR DESCRIPTION
Fixes #94

This PR updates `PolicyEngine.from_config()` to log a warning when encountering an unrecognized policy check name (such as typos like `"check": "freshnes"`), rather than silently skipping the entry.

## Problem

Previously, if a policy configuration entry contained an unknown check name, `PolicyEngine.from_config()` silently ignored it without logging any warning or error. In a context governance system, this silently left an enforcement gap with no visibility to operators or developers.

## Solution

1. Added an `else` branch in `PolicyEngine.from_config()` inside [src/provena/policy.py](file:///c:/Users/shahb/provena/src/provena/policy.py#L182-L190) that logs a warning message detailing the invalid check name and listing valid check options (`freshness`, `provenance`, `require_signing`, `source_allowlist`).
2. Preserved existing behavior: unknown checks are still skipped (zero policies created).
3. Updated `test_unknown_check_ignored` in [tests/test_policy.py](file:///c:/Users/shahb/provena/tests/test_policy.py#L220-L230) using pytest's `caplog` fixture to verify that the warning is emitted and contains the expected message.

## Changes

- **[src/provena/policy.py](file:///c:/Users/shahb/provena/src/provena/policy.py#L182-L190)**: Added `_logger.warning(...)` call in `PolicyEngine.from_config()`.
- **[tests/test_policy.py](file:///c:/Users/shahb/provena/tests/test_policy.py#L220-L230)**: Added `import logging` and `caplog` assertions to `test_unknown_check_ignored`.

## Verification Plan

### Automated Tests
Run unit tests for policy engine configuration:
```bash
pytest tests/test_policy.py::TestPolicyEngineFromConfig::test_unknown_check_ignored -v