### PR TITLE
fix: skip malformed policy enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Provena are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Malformed policy enforcement values** — invalid `enforcement` settings now
+  log a warning and skip only the affected policy entry instead of crashing
+  `PolicyEngine.from_config()` (#109)
+
 ## [1.0.1] - 2026-07-25
 
 ### Fixed

--- a/src/provena/policy.py
+++ b/src/provena/policy.py
@@ -165,7 +165,17 @@ class PolicyEngine:
         policies: list[Policy] = []
         for entry in config:
             check_name = entry.get("check", "")
-            enforcement = EnforcementLevel(entry.get("enforcement", "log"))
+            enforcement_value = entry.get("enforcement", "log")
+            try:
+                enforcement = EnforcementLevel(enforcement_value)
+            except ValueError:
+                _logger.warning(
+                    "Invalid enforcement level %r for policy check %r — skipping. "
+                    "Valid levels: log, warn, block",
+                    enforcement_value,
+                    check_name,
+                )
+                continue
 
             if check_name == "freshness":
                 status = entry.get("status", "STALE")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -229,6 +229,18 @@ class TestPolicyEngineFromConfig:
         assert any("Unknown policy check" in msg for msg in caplog.messages)
         assert any("nonexistent" in msg for msg in caplog.messages)
 
+    def test_invalid_enforcement_ignored(self, caplog):
+        config = [
+            {"check": "freshness", "enforcement": "blocked"},
+            {"check": "provenance", "enforcement": "warn"},
+        ]
+        with caplog.at_level(logging.WARNING, logger="provena.policy"):
+            engine = PolicyEngine.from_config(config)
+        assert len(engine.policies) == 1
+        assert engine.policies[0].name == "provenance:MISSING"
+        assert any("Invalid enforcement level" in msg for msg in caplog.messages)
+        assert any("blocked" in msg for msg in caplog.messages)
+
 
 class TestBuiltInPolicies:
     def test_freshness_check_blocks_stale(self):


### PR DESCRIPTION
## What does this PR do?

`PolicyEngine.from_config()` now logs a warning and skips only the affected entry when an `enforcement` value is invalid. Valid policy entries that follow it continue loading normally.

The regression test covers the warning, the skipped malformed entry, and preservation of a subsequent valid policy. The behavior is also recorded under the Unreleased changelog.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures (444 passed, 23 optional-dependency/service skips)
- [x] CHANGELOG.md updated (if user-facing change)

## Related Issues

Fixes #109
