### PR TITLE
fix(cli): handle invalid config errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Provena are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- CLI commands now report missing or invalid `--config` files without a traceback (#108)
+
 ## [1.0.1] - 2026-07-25
 
 ### Fixed

--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -47,6 +47,26 @@ def cli(
     ctx.obj["signing_key"] = signing_key
 
 
+def _open_trail(ctx: click.Context) -> tuple[ContextTrail, str]:
+    """Open the configured trail or exit with a concise CLI error."""
+    config_path = ctx.obj.get("config_path")
+    if config_path:
+        try:
+            return ContextTrail(config=config_path), config_path
+        except (FileNotFoundError, ValueError) as exc:
+            click.echo(str(exc), err=True)
+            ctx.exit(1)
+
+    db_path = ctx.obj["db"]
+    if not _is_pg_url(db_path) and not os.path.exists(db_path):
+        click.echo(f"Database not found: {db_path}", err=True)
+        ctx.exit(1)
+    return (
+        ContextTrail(storage_path=db_path, signing_key=ctx.obj.get("signing_key")),
+        db_path,
+    )
+
+
 @cli.command()
 @click.option("--source", "-s", default=None, help="Filter by source type.")
 @click.option("--limit", "-n", default=20, type=int, help="Max records to show.")
@@ -81,18 +101,7 @@ def audit(
     fmt: str,
 ) -> None:
     """Query the context governance audit log."""
-    config_path = ctx.obj.get("config_path")
-    if config_path:
-        trail = ContextTrail(config=config_path)
-    else:
-        db_path = ctx.obj["db"]
-        if not _is_pg_url(db_path) and not os.path.exists(db_path):
-            click.echo(f"Database not found: {db_path}", err=True)
-            ctx.exit(1)
-            return
-        trail = ContextTrail(
-            storage_path=db_path, signing_key=ctx.obj.get("signing_key")
-        )
+    trail, _ = _open_trail(ctx)
     try:
         records = trail.query(source=source, limit=limit, start=start, end=end)
 
@@ -112,18 +121,7 @@ def audit(
 @click.pass_context
 def verify(ctx: click.Context) -> None:
     """Verify the integrity of the hash-chained audit trail."""
-    config_path = ctx.obj.get("config_path")
-    if config_path:
-        trail = ContextTrail(config=config_path)
-    else:
-        db_path = ctx.obj["db"]
-        if not _is_pg_url(db_path) and not os.path.exists(db_path):
-            click.echo(f"Database not found: {db_path}", err=True)
-            ctx.exit(1)
-            return
-        trail = ContextTrail(
-            storage_path=db_path, signing_key=ctx.obj.get("signing_key")
-        )
+    trail, _ = _open_trail(ctx)
     try:
         verdict = trail.verify_chain()
 
@@ -157,19 +155,7 @@ def verify(ctx: click.Context) -> None:
 @click.pass_context
 def report(ctx: click.Context, fmt: str, output: str | None) -> None:
     """Generate a context governance compliance report."""
-    config_path = ctx.obj.get("config_path")
-    if config_path:
-        trail = ContextTrail(config=config_path)
-        db_path = config_path  # Use config path for report metadata
-    else:
-        db_path = ctx.obj["db"]
-        if not _is_pg_url(db_path) and not os.path.exists(db_path):
-            click.echo(f"Database not found: {db_path}", err=True)
-            ctx.exit(1)
-            return
-        trail = ContextTrail(
-            storage_path=db_path, signing_key=ctx.obj.get("signing_key")
-        )
+    trail, db_path = _open_trail(ctx)
     try:
         summary = trail.summary()
         verdict = trail.verify_chain()
@@ -243,18 +229,7 @@ def retain(
     ctx: click.Context, max_age: int, archive: str | None, dry_run: bool
 ) -> None:
     """Apply retention policy — delete old records with optional archive."""
-    config_path = ctx.obj.get("config_path")
-    if config_path:
-        trail = ContextTrail(config=config_path)
-    else:
-        db_path = ctx.obj["db"]
-        if not _is_pg_url(db_path) and not os.path.exists(db_path):
-            click.echo(f"Database not found: {db_path}", err=True)
-            ctx.exit(1)
-            return
-        trail = ContextTrail(
-            storage_path=db_path, signing_key=ctx.obj.get("signing_key")
-        )
+    trail, _ = _open_trail(ctx)
     try:
         from provena.retention import RetentionEngine
 
@@ -285,18 +260,7 @@ def retain(
 @click.pass_context
 def summary(ctx: click.Context) -> None:
     """Show a quick summary of the audit trail."""
-    config_path = ctx.obj.get("config_path")
-    if config_path:
-        trail = ContextTrail(config=config_path)
-    else:
-        db_path = ctx.obj["db"]
-        if not _is_pg_url(db_path) and not os.path.exists(db_path):
-            click.echo(f"Database not found: {db_path}", err=True)
-            ctx.exit(1)
-            return
-        trail = ContextTrail(
-            storage_path=db_path, signing_key=ctx.obj.get("signing_key")
-        )
+    trail, _ = _open_trail(ctx)
     try:
         s = trail.summary()
         h = trail.health()

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -860,8 +860,11 @@ def _load_config_file(path: str | Path) -> dict[str, Any]:
                 "PyYAML is required for YAML config files. "
                 "Install with: pip install provena[yaml]"
             ) from None
-        with open(filepath) as f:
-            data = yaml.safe_load(f)
+        try:
+            with open(filepath) as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError:
+            raise ValueError(f"Invalid YAML config: {filepath}") from None
         if not isinstance(data, dict):
             raise ValueError(
                 f"YAML config must be a mapping, got {type(data).__name__}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 
+import pytest
 from click.testing import CliRunner
 
 from provena.cli.main import cli
@@ -22,6 +23,40 @@ def _create_trail_db(num_records: int = 3) -> str:
         trail.log(f"context entry {i}", source="retriever", source_name=f"src_{i}")
     trail.close()
     return db_path
+
+
+@pytest.mark.parametrize("command", ["audit", "verify", "report", "retain", "summary"])
+def test_missing_config_error_is_clean(command: str, tmp_path):
+    config_path = tmp_path / "missing.toml"
+
+    result = CliRunner().invoke(cli, ["--config", str(config_path), command])
+
+    assert result.exit_code == 1
+    assert result.output == f"Config file not found: {config_path}\n"
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize("command", ["audit", "verify", "report", "retain", "summary"])
+def test_malformed_yaml_config_error_is_clean(command: str, tmp_path):
+    config_path = tmp_path / "invalid.yaml"
+    config_path.write_text("storage: [")
+
+    result = CliRunner().invoke(cli, ["--config", str(config_path), command])
+
+    assert result.exit_code == 1
+    assert result.output == f"Invalid YAML config: {config_path}\n"
+    assert "Traceback" not in result.output
+
+
+def test_unsupported_config_error_is_clean(tmp_path):
+    config_path = tmp_path / "invalid.txt"
+    config_path.write_text("not a supported config")
+
+    result = CliRunner().invoke(cli, ["--config", str(config_path), "audit"])
+
+    assert result.exit_code == 1
+    assert "Unsupported config file format: '.txt'" in result.output
+    assert "Traceback" not in result.output
 
 
 class TestCLIAudit:

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -78,6 +78,13 @@ class TestConfigErrors:
         with pytest.raises(ValueError, match="YAML config must be a mapping"):
             ContextTrail(config=str(config_file))
 
+    def test_malformed_yaml_raises_value_error(self, tmp_path):
+        config_file = tmp_path / "malformed.yaml"
+        config_file.write_text("storage: [")
+
+        with pytest.raises(ValueError, match="Invalid YAML config"):
+            ContextTrail(config=str(config_file))
+
     def test_empty_config_dict_uses_defaults(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         trail = ContextTrail(config={})


### PR DESCRIPTION
## What does this PR do?

Adds a shared CLI trail opener so `audit`, `verify`, `report`, `retain`, and `summary` report missing or invalid `--config` files as concise errors instead of exposing Python tracebacks.

YAML parser failures are normalized to `ValueError`, keeping configuration-loading errors consistent for library and CLI callers.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

## Related Issues

Fixes #108
