### PR TITLE
fix: include signed flag in empty ContextTrail.summary()

### DIFF
--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -667,7 +667,13 @@ class ContextTrail:
         records = self._backend.all_records()
         total = len(records)
         if total == 0:
-            return {"total": 0, "provenance": {}, "freshness": {}, "sources": {}}
+            return {
+                "total": 0,
+                "provenance": {},
+                "freshness": {},
+                "sources": {},
+                "signed": self._hasher.is_signed,
+            }
 
         prov_counts: dict[str, int] = {}
         fresh_counts: dict[str, int] = {}

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -530,6 +530,12 @@ class TestContextTrailExport:
 
 
 class TestContextTrailSigning:
+    def test_empty_signed_trail_summary_includes_signed(self):
+        trail = ContextTrail(backend="memory", signing_key="supersecret")
+        summary = trail.summary()
+        assert summary["total"] == 0
+        assert summary["signed"] is True
+
     def test_signed_trail(self):
         trail = ContextTrail(backend="memory", signing_key="test-secret")
         assert trail.is_signed


### PR DESCRIPTION
## Summary
- Include `"signed"` on the empty-trail early return in `ContextTrail.summary()`.
- Add a regression test for an empty HMAC-signed trail.

Closes #117