### PR TITLE
fix(trail): include signed key in empty summary

### DIFF
--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -667,7 +667,13 @@ class ContextTrail:
         records = self._backend.all_records()
         total = len(records)
         if total == 0:
-            return {"total": 0, "provenance": {}, "freshness": {}, "sources": {}}
+            return {
+                "total": 0,
+                "provenance": {},
+                "freshness": {},
+                "sources": {},
+                "signed": self._hasher.is_signed,
+            }
 
         prov_counts: dict[str, int] = {}
         fresh_counts: dict[str, int] = {}

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -398,6 +398,14 @@ class TestContextTrailSummary:
     def test_summary_empty(self, memory_trail):
         s = memory_trail.summary()
         assert s["total"] == 0
+        assert s["signed"] is False
+
+    def test_summary_empty_signed_includes_signed_true(self):
+        trail = ContextTrail(backend="memory", signing_key="supersecret")
+        s = trail.summary()
+        assert s["total"] == 0
+        assert s["signed"] is True
+        trail.close()
 
     def test_summary_with_records(self, memory_trail):
         prov = ProvenanceMetadata(


### PR DESCRIPTION
Closes #117.

`ContextTrail.summary()` early-returned for empty trails without a `signed` key, so signed-but-empty trails looked unsigned to `.get("signed", False)` callers. The empty path now includes `"signed": self._hasher.is_signed`, matching the non-empty path.

Made with [Cursor](https://cursor.com)