### PR TITLE
fix(trail): validate query limit is >= 1 (closes #101)

### DIFF
--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -10,6 +10,18 @@ import click
 from provena.trail import ContextTrail, _is_pg_url
 
 
+def _positive_int(ctx: click.Context, param: click.Parameter, value: int) -> int:
+    """Reject non-positive --limit values with a clean Click error.
+
+    ``ContextTrail.query`` raises ``ValueError`` for ``limit < 1``; validating
+    here turns that into the standard "Invalid value" message instead of an
+    unhandled traceback.
+    """
+    if value < 1:
+        raise click.BadParameter("must be >= 1")
+    return value
+
+
 @click.group()
 @click.option(
     "--db",
@@ -69,7 +81,14 @@ def _open_trail(ctx: click.Context) -> tuple[ContextTrail, str]:
 
 @cli.command()
 @click.option("--source", "-s", default=None, help="Filter by source type.")
-@click.option("--limit", "-n", default=20, type=int, help="Max records to show.")
+@click.option(
+    "--limit",
+    "-n",
+    default=20,
+    type=int,
+    callback=_positive_int,
+    help="Max records to show (must be >= 1).",
+)
 @click.option(
     "--from",
     "start",

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -605,11 +605,19 @@ class ContextTrail:
             end: Include only records at or before this timestamp.
             provenance_status: Filter by provenance validation status.
             freshness_status: Filter by freshness check status.
-            limit: Maximum number of records to return.
+            limit: Maximum number of records to return. Must be >= 1.
 
         Returns:
             A list of record dictionaries matching the filters.
+
+        Raises:
+            ValueError: If ``limit`` is less than 1. Passing ``limit <= 0``
+                was previously silent and backend-dependent — SQLite treated
+                ``LIMIT -1`` as "no limit" and ``LIMIT 0`` as "no rows", while
+                PostgreSQL rejects a negative ``LIMIT`` outright.
         """
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
         source_str = source.value if isinstance(source, ContextSource) else source
         return self._backend.query(
             source=source_str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,6 +117,19 @@ class TestCLIAudit:
         finally:
             os.unlink(db_path)
 
+    @pytest.mark.parametrize("bad_limit", ["0", "-1"])
+    def test_audit_rejects_nonpositive_limit(self, bad_limit):
+        db_path = _create_trail_db(3)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["--db", db_path, "audit", "--limit", bad_limit]
+            )
+            assert result.exit_code != 0
+            assert "Invalid value for '--limit'" in result.output
+        finally:
+            os.unlink(db_path)
+
     def test_audit_from_date(self):
         db_path = _create_trail_db()
         try:

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -301,6 +301,25 @@ class TestContextTrailQuery:
         results = memory_trail.query(limit=3)
         assert len(results) == 3
 
+    def test_query_rejects_zero_limit(self, trail):
+        # limit=0 previously returned no records silently (SQLite "LIMIT 0").
+        trail.log("a", source="retriever")
+        with pytest.raises(ValueError, match="limit must be >= 1"):
+            trail.query(limit=0)
+
+    def test_query_rejects_negative_limit(self, trail):
+        # limit=-1 previously returned ALL records silently (SQLite "LIMIT -1"),
+        # while PostgreSQL would raise — this pins one cross-backend behaviour.
+        trail.log("a", source="retriever")
+        with pytest.raises(ValueError, match="limit must be >= 1"):
+            trail.query(limit=-1)
+
+    def test_query_limit_one_is_allowed(self, trail):
+        # The boundary: 1 is the smallest valid limit and must still work.
+        trail.log("a", source="retriever")
+        trail.log("b", source="retriever")
+        assert len(trail.query(limit=1)) == 1
+
     def test_query_by_governance_status(self, memory_trail):
         memory_trail.log("missing", source="retriever")
         memory_trail.log(


### PR DESCRIPTION
## Summary

Closes #101

`ContextTrail.query()` passed `limit` straight through to the storage backend with no validation. For `limit <= 0` the result was silent and **backend-dependent**:

- SQLite treated `LIMIT -1` as "no limit" (returned **all** records) and `LIMIT 0` as "no rows".
- PostgreSQL rejects a negative `LIMIT` outright with a database error.

The same call returned different results on different backends, and nothing raised or warned.

## Changes

- **`src/provena/trail.py`** — `ContextTrail.query()` now raises `ValueError` when `limit < 1`, documented in the docstring's `Raises:` section. `limit` is typed `int` (default `100`) and every in-tree caller already passes a positive value, so this rejects only the previously-undefined inputs — no existing behaviour changes.
- **`src/provena/cli/main.py`** — `provena audit --limit/-n` gains a small Click callback (`_positive_int`) so a non-positive value produces the standard `Invalid value for '--limit'` message instead of letting the new `ValueError` surface as an unhandled traceback. This mirrors the existing `--from`/`--to` validation behaviour (`test_audit_invalid_date`).

## Tests

- `tests/test_trail.py` — `limit=0` and `limit=-1` raise `ValueError` on the SQLite backend; `limit=1` (the boundary) still returns one row.
- `tests/test_cli.py` — `provena audit --limit 0` and `--limit -1` exit non-zero with the standard invalid-value message (parametrized).

## Verification

Ran the full local gate from `CONTRIBUTING.md`:

- `ruff check src/ tests/` — clean
- `ruff format --check` — clean
- `mypy src/provena/` — `Success: no issues found in 27 source files`
- `pytest` (excluding optional-extra modules I don't have installed: otel/pg/adapters/integrations) — **430 passed, 2 skipped**, including the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)