### PR TITLE
test(mcp): cover tool function responses

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import pytest
 
@@ -34,6 +36,70 @@ def trail_empty():
     trail.close()
 
 
+@pytest.fixture
+def trail_summary_data():
+    trail = ContextTrail(backend="memory")
+    now = datetime.now(timezone.utc)
+    for index in range(3):
+        trail.log(
+            f"valid record {index}",
+            source="retriever",
+            source_name=f"docs-{index}",
+            provenance=ProvenanceMetadata(
+                source_url="https://example.com",
+                created_at=now - timedelta(days=index + 1),
+            ),
+        )
+    trail.log("missing provenance", source="tool", source_name="api")
+    trail.log(
+        "incomplete provenance",
+        source="agent",
+        source_name="planner",
+        provenance=ProvenanceMetadata(source_url="https://example.com"),
+    )
+    configure(trail)
+    yield trail
+    trail.close()
+
+
+@pytest.fixture
+def trail_all_valid():
+    trail = ContextTrail(backend="memory")
+    now = datetime.now(timezone.utc)
+    for index in range(2):
+        trail.log(
+            f"valid record {index}",
+            source="retriever",
+            source_name=f"docs-{index}",
+            provenance=ProvenanceMetadata(
+                source_url="https://example.com",
+                created_at=now - timedelta(days=index + 1),
+            ),
+        )
+    configure(trail)
+    yield trail
+    trail.close()
+
+
+@pytest.fixture
+def trail_all_violations():
+    trail = ContextTrail(backend="memory")
+    trail.log(
+        "Data as of 2000-01-01",
+        source="mcp",
+        source_name="stale-missing",
+    )
+    trail.log(
+        "partial provenance",
+        source="tool",
+        source_name="partial",
+        provenance=ProvenanceMetadata(source_url="https://example.com"),
+    )
+    configure(trail)
+    yield trail
+    trail.close()
+
+
 _has_fastmcp = False
 try:
     import fastmcp  # noqa: F401
@@ -41,6 +107,17 @@ try:
     _has_fastmcp = True
 except ImportError:
     pass
+
+
+def _call_tool(
+    server: Any,
+    name: str,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    result = asyncio.run(server.call_tool(name, arguments or {}))
+    assert not result.is_error
+    assert result.content
+    return json.loads(result.content[0].text)
 
 
 class TestMCPServerCreation:
@@ -75,6 +152,125 @@ class TestConfigureAndGetTrail:
 
 class TestMCPToolFunctions:
     """Test the tool functions directly (without FastMCP transport)."""
+
+    @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+    def test_list_violations_deduplicates_records(self):
+        trail = ContextTrail(backend="memory")
+        trail.log(
+            "Data as of 2000-01-01",
+            source="mcp",
+            source_name="stale-missing",
+        )
+        trail.log(
+            "partial provenance",
+            source="tool",
+            source_name="partial",
+            provenance=ProvenanceMetadata(source_url="https://example.com"),
+        )
+        configure(trail)
+        try:
+            result = _call_tool(create_server(), "list_violations")
+        finally:
+            trail.close()
+
+        assert result["total_violations"] == 2
+        assert len(result["violations"]) == 2
+        assert len({item["id"] for item in result["violations"]}) == 2
+        assert {
+            (item["provenance_status"], item["freshness_status"])
+            for item in result["violations"]
+        } == {("MISSING", "STALE"), ("INCOMPLETE", "UNKNOWN")}
+
+    @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+    def test_get_summary_reports_percentages(self, trail_summary_data):
+        result = _call_tool(create_server(), "get_summary")
+
+        assert result["total"] == 5
+        assert result["provenance"] == {"VALID": 3, "MISSING": 1, "INCOMPLETE": 1}
+        assert result["freshness"] == {"FRESH": 3, "UNKNOWN": 2}
+        assert result["provenance_valid_pct"] == 60
+        assert result["freshness_fresh_pct"] == 60
+        assert result["recommendation"] == "60% provenance valid, 60% fresh."
+
+    @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+    def test_check_freshness_filters_and_reports_stale_entries(self):
+        trail = ContextTrail(backend="memory")
+        now = datetime.now(timezone.utc)
+        trail.log(
+            "old data",
+            source="retriever",
+            source_name="old-docs",
+            provenance=ProvenanceMetadata(
+                source_url="https://example.com/old",
+                created_at=now - timedelta(days=180),
+            ),
+        )
+        trail.log(
+            "fresh data",
+            source="retriever",
+            source_name="new-docs",
+            provenance=ProvenanceMetadata(
+                source_url="https://example.com/new",
+                created_at=now - timedelta(days=1),
+            ),
+        )
+        trail.log("other source", source="tool", source_name="api")
+        configure(trail)
+        try:
+            result = _call_tool(
+                create_server(),
+                "check_freshness",
+                {"source": "retriever", "limit": 10},
+            )
+        finally:
+            trail.close()
+
+        assert result["total_checked"] == 2
+        assert result["fresh"] == 1
+        assert result["stale"] == 1
+        assert result["unknown"] == 0
+        assert result["stale_entries"] == [
+            {"id": 1, "source": "retriever", "source_name": "old-docs"}
+        ]
+        assert "1 stale entries detected" in result["recommendation"]
+
+    @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+    def test_check_provenance_filters_and_counts_statuses(self):
+        trail = ContextTrail(backend="memory")
+        now = datetime.now(timezone.utc)
+        trail.log(
+            "valid tool data",
+            source="tool",
+            source_name="api-valid",
+            provenance=ProvenanceMetadata(
+                source_url="https://example.com",
+                created_at=now,
+            ),
+        )
+        trail.log("missing tool data", source="tool", source_name="api-missing")
+        trail.log(
+            "incomplete retriever data",
+            source="retriever",
+            source_name="docs-partial",
+            provenance=ProvenanceMetadata(source_url="https://example.com"),
+        )
+        configure(trail)
+        try:
+            result = _call_tool(
+                create_server(),
+                "check_provenance",
+                {"source": "tool", "limit": 10},
+            )
+        finally:
+            trail.close()
+
+        assert result == {
+            "total_checked": 2,
+            "valid": 1,
+            "missing": 1,
+            "incomplete": 0,
+            "recommendation": "1 missing, 0 incomplete — attach provenance metadata.",
+        }
 
     def test_check_freshness(self, trail_with_data):
         from provena.mcp_server import create_server
@@ -124,6 +320,62 @@ class TestMCPToolFunctions:
         trail = get_trail()
         assert trail.summary()["total"] == 0
         assert trail.verify_chain().intact
+
+    @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+    def test_empty_tool_responses(self, trail_empty):
+        server = create_server()
+
+        assert _call_tool(server, "list_violations")["total_violations"] == 0
+        assert _call_tool(server, "get_summary")["recommendation"] == (
+            "No records in the audit trail."
+        )
+        assert _call_tool(server, "check_freshness") == {
+            "total_checked": 0,
+            "fresh": 0,
+            "stale": 0,
+            "unknown": 0,
+            "recommendation": "All context is fresh.",
+        }
+        assert _call_tool(server, "check_provenance") == {
+            "total_checked": 0,
+            "valid": 0,
+            "missing": 0,
+            "incomplete": 0,
+            "recommendation": "All entries have valid provenance.",
+        }
+
+    @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+    def test_all_valid_tool_responses(self, trail_all_valid):
+        server = create_server()
+
+        assert _call_tool(server, "list_violations")["total_violations"] == 0
+        summary = _call_tool(server, "get_summary")
+        assert summary["provenance_valid_pct"] == 100
+        assert summary["freshness_fresh_pct"] == 100
+        assert _call_tool(server, "check_freshness")["stale"] == 0
+        assert _call_tool(server, "check_provenance") == {
+            "total_checked": 2,
+            "valid": 2,
+            "missing": 0,
+            "incomplete": 0,
+            "recommendation": "All entries have valid provenance.",
+        }
+
+    @pytest.mark.skipif(not _has_fastmcp, reason="fastmcp not installed")
+    def test_all_violation_tool_responses(self, trail_all_violations):
+        server = create_server()
+
+        violations = _call_tool(server, "list_violations")
+        assert violations["total_violations"] == 2
+        assert "2 violations" in violations["recommendation"]
+        summary = _call_tool(server, "get_summary")
+        assert summary["provenance_valid_pct"] == 0
+        freshness = _call_tool(server, "check_freshness")
+        assert freshness["stale"] == 1
+        assert freshness["unknown"] == 1
+        provenance = _call_tool(server, "check_provenance")
+        assert provenance["missing"] == 1
+        assert provenance["incomplete"] == 1
 
 
 class TestMCPCLI:


### PR DESCRIPTION
## Summary

- Add focused tests for the public FastMCP tool surface in `tests/test_mcp_server.py`.
- Exercise `server.call_tool(...)` responses for `list_violations`, `get_summary`, `check_freshness`, and `check_provenance`.
- Cover deduplication, percentage/recommendation shaping, source filtering, stale/unknown states, and empty/all-valid/all-violation edge cases.
- No production code changes.

Closes #95

## Validation

- `.venv/bin/pytest -q` — 478 passed, 22 skipped.
- `.venv/bin/pytest --cov=provena -q` — 478 passed, 22 skipped; 82% total coverage.
- `.venv/bin/ruff check src/ tests/` — passed.
- `.venv/bin/ruff format --check src/ tests/` — passed.
- `.venv/bin/mypy src/provena/` — one pre-existing error at `src/provena/mcp_server.py:13`: optional `FastMCP = None` is incompatible with the inferred FastMCP type. This PR does not modify that file.