### PR TITLE
TrailAggregator.query(trail_label=...) silently returns all trail...

### DIFF
--- a/src/provena/aggregator.py
+++ b/src/provena/aggregator.py
@@ -223,7 +223,11 @@ class TrailAggregator:
         source_str = source.value if isinstance(source, ContextSource) else source
 
         if trail_label is not None:
-            targets = {trail_label: self._trails[trail_label]} if trail_label in self._trails else {}
+            targets = (
+                {trail_label: self._trails[trail_label]}
+                if trail_label in self._trails
+                else {}
+            )
         else:
             targets = self._trails
 

--- a/src/provena/aggregator.py
+++ b/src/provena/aggregator.py
@@ -222,11 +222,10 @@ class TrailAggregator:
         """
         source_str = source.value if isinstance(source, ContextSource) else source
 
-        targets = (
-            {trail_label: self._trails[trail_label]}
-            if trail_label and trail_label in self._trails
-            else self._trails
-        )
+        if trail_label is not None:
+            targets = {trail_label: self._trails[trail_label]} if trail_label in self._trails else {}
+        else:
+            targets = self._trails
 
         results: list[dict[str, Any]] = []
         per_trail_limit = max(1, limit // max(len(targets), 1))

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -158,6 +158,10 @@ class TestAggregatedQuery:
         assert len(records) == 2
         assert all(r["_trail"] == "planner" for r in records)
 
+    def test_query_by_unknown_trail_label(self, populated_aggregator):
+        records = populated_aggregator.query(trail_label="nonexistent_agent")
+        assert len(records) == 0
+
     def test_query_by_source(self, populated_aggregator):
         records = populated_aggregator.query(source="tool")
         assert len(records) >= 2


### PR DESCRIPTION
Fixes #107

Fixed TrailAggregator.query() to return an empty result instead of all trails when queried with an unknown trail_label.

**Testing:** Added test_query_by_unknown_trail_label in tests/test_aggregator.py and verified that the test suite passes.

---

## What does this PR do?

<!-- A clear description of what this PR changes and why. -->

## Checklist

- [ ] Tests added/updated for the change
- [ ] `ruff check src/ tests/` passes
- [ ] `ruff format --check src/ tests/` passes
- [ ] `mypy src/provena/` passes
- [ ] `pytest` passes with no failures
- [ ] CHANGELOG.md updated (if user-facing change)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->