### PR TITLE
ProvenanceMetadata.from_dict() and framework integrations break o...

### DIFF
--- a/src/provena/integrations/langchain.py
+++ b/src/provena/integrations/langchain.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
-from provena.models import ContextSource, ProvenanceMetadata
+from provena.models import ContextSource, ProvenanceMetadata, parse_isoformat
 
 if TYPE_CHECKING:
     from provena.trail import ContextTrail
@@ -102,7 +102,7 @@ def _parse_datetime(value: Any) -> datetime | None:
         return value
     if isinstance(value, str):
         try:
-            return datetime.fromisoformat(value)
+            return parse_isoformat(value)
         except ValueError:
             return None
     return None

--- a/src/provena/integrations/llamaindex.py
+++ b/src/provena/integrations/llamaindex.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from provena.models import ContextSource, ProvenanceMetadata
+from provena.models import ContextSource, ProvenanceMetadata, parse_isoformat
 
 if TYPE_CHECKING:
     from provena.trail import ContextTrail
@@ -94,7 +94,7 @@ def _parse_datetime(value: Any) -> datetime | None:
         return value
     if isinstance(value, str):
         try:
-            return datetime.fromisoformat(value)
+            return parse_isoformat(value)
         except ValueError:
             return None
     return None

--- a/src/provena/models.py
+++ b/src/provena/models.py
@@ -21,6 +21,17 @@ class ContextSource(str, Enum):
     CUSTOM = "custom"
 
 
+def parse_isoformat(dt_str: str) -> datetime:
+    """Parse an ISO 8601 formatted datetime string.
+
+    Handles the 'Z' suffix for UTC which is not supported by datetime.fromisoformat
+    in Python 3.10.
+    """
+    if dt_str.endswith("Z"):
+        dt_str = dt_str[:-1] + "+00:00"
+    return datetime.fromisoformat(dt_str)
+
+
 @dataclass(frozen=True, slots=True)
 class ProvenanceMetadata:
     """Immutable metadata about the origin and authorship of a context input.
@@ -59,7 +70,7 @@ class ProvenanceMetadata:
         """Reconstruct a ProvenanceMetadata instance from a dictionary."""
         created_at = data.get("created_at")
         if isinstance(created_at, str):
-            created_at = datetime.fromisoformat(created_at)
+            created_at = parse_isoformat(created_at)
         return cls(
             source_url=data.get("source_url"),
             author=data.get("author"),

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -24,6 +24,7 @@ from provena.models import (
     ContextSource,
     ProvenanceMetadata,
     TrailRecord,
+    parse_isoformat,
 )
 from provena.policy import (
     EnforcementLevel,
@@ -538,7 +539,7 @@ class ContextTrail:
             )
             if isinstance(created_at, str):
                 try:
-                    created_at = datetime.fromisoformat(created_at)
+                    created_at = parse_isoformat(created_at)
                 except ValueError:
                     created_at = None
             elif not isinstance(created_at, datetime):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -73,6 +73,18 @@ class TestProvenanceMetadata:
         d = pm.to_dict()
         assert d == {}
 
+    def test_from_dict_isoformat_with_z(self):
+        # Parameterized over different common ISO formats
+        variants = [
+            "2024-01-15T10:00:00Z",
+            "2024-01-15T10:00:00+00:00",
+        ]
+        for v in variants:
+            d = {"created_at": v}
+            pm = ProvenanceMetadata.from_dict(d)
+            assert pm.created_at is not None
+            assert pm.created_at.isoformat() == "2024-01-15T10:00:00+00:00"
+
     def test_frozen(self):
         pm = ProvenanceMetadata(source_url="https://example.com")
         import pytest


### PR DESCRIPTION
Fixes #99

Added parse_isoformat helper to safely parse Z-suffixed ISO timestamps on Python 3.10 and updated usages in models.py, trail.py, langchain.py, and llamaindex.py.

**Testing:** Added a parameterized test test_from_dict_isoformat_with_z covering standard and Z-suffixed variants.

---

## What does this PR do?

<!-- A clear description of what this PR changes and why. -->

## Checklist

- [ ] Tests added/updated for the change
- [ ] `ruff check src/ tests/` passes
- [ ] `ruff format --check src/ tests/` passes
- [ ] `mypy src/provena/` passes
- [ ] `pytest` passes with no failures
- [ ] CHANGELOG.md updated (if user-facing change)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->