### PR TITLE
fix(cli): validate migrate --batch-size is >= 1 (closes #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `PolicyEngine.from_config()` (#109)
 - **`TrailAggregator.summary()`** now includes an `all_signed` field, matching
   the `signed` field already present on `ContextTrail.summary()` (#110)
+- **`migrate --batch-size` validation** — non-positive batch sizes now fail with
+  a clear CLI error instead of crashing (`0`) or silently migrating zero records
+  while reporting `PASS` (`-1`) (#106)
 
 ## [1.0.1] - 2026-07-25
 

--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -11,11 +11,13 @@ from provena.trail import ContextTrail, _is_pg_url
 
 
 def _positive_int(ctx: click.Context, param: click.Parameter, value: int) -> int:
-    """Reject non-positive --limit values with a clean Click error.
+    """Reject non-positive integer option values with a clean Click error.
 
-    ``ContextTrail.query`` raises ``ValueError`` for ``limit < 1``; validating
-    here turns that into the standard "Invalid value" message instead of an
-    unhandled traceback.
+    Used by ``--limit`` and ``--batch-size``. ``ContextTrail.query`` raises
+    ``ValueError`` for ``limit < 1``, and a non-positive ``batch_size`` makes
+    ``migrate`` either crash or silently copy nothing; validating here turns
+    both into the standard "Invalid value" message instead of an unhandled
+    traceback.
     """
     if value < 1:
         raise click.BadParameter("must be >= 1")
@@ -367,7 +369,8 @@ def serve(ctx: click.Context, db: str | None, transport: str) -> None:
     "--batch-size",
     default=500,
     type=int,
-    help="Number of records per batch.",
+    callback=_positive_int,
+    help="Number of records per batch (must be >= 1).",
 )
 @click.pass_context
 def migrate(

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from click.testing import CliRunner
 
 from provena import ContextTrail
@@ -89,6 +90,37 @@ class TestMigrateSQLiteToSQLite:
         )
         assert result.exit_code == 0
         assert "20 records" in result.output
+
+    @pytest.mark.parametrize("bad_batch_size", ["0", "-1"])
+    def test_migrate_rejects_nonpositive_batch_size(self, tmp_path, bad_batch_size):
+        # batch_size=0 previously crashed with a raw "range() arg 3 must not be
+        # zero" traceback. batch_size=-1 was worse: range(0, total, -1) is empty,
+        # so nothing was written, and the empty destination verified as "intact"
+        # — the command reported PASS using the *source* record count.
+        src_path = str(tmp_path / "source.db")
+        dst_path = str(tmp_path / "dest.db")
+
+        trail = ContextTrail(storage_path=src_path)
+        for i in range(5):
+            trail.log(f"record {i}", source="retriever")
+        trail.close()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "migrate",
+                "--from",
+                src_path,
+                "--to",
+                dst_path,
+                "--batch-size",
+                bad_batch_size,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Invalid value for '--batch-size'" in result.output
+        assert "PASS" not in result.output
 
     def test_migrate_copies_annotations(self, tmp_path):
         src_path = str(tmp_path / "source.db")


### PR DESCRIPTION
## What does this PR do?

`provena migrate --batch-size` accepted `0` and negative values with no validation.

- `--batch-size 0` crashed with a raw `ValueError: range() arg 3 must not be zero` traceback.
- `--batch-size -1` was worse: `range(0, total, -1)` is empty, so the loop body never ran and
  nothing was written to the destination. The empty destination then verified as trivially
  "intact", so the command printed `PASS — Migrated 5 records` using the **source** record
  count — reporting complete data loss as success.

Both now fail up front with the standard Click error:

```
Error: Invalid value for '--batch-size': must be >= 1
```

Rather than adding `click.IntRange(min=1)`, this reuses the `_positive_int` callback already in
`cli/main.py` (added in #122 for `--limit`), so both options produce identical error messages.
The `range()` loop is left unchanged — once the boundary rejects values below 1 it is already
correct.

`_positive_int`'s docstring said "Reject non-positive `--limit` values"; it now covers both call
sites.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

## Related Issues

Fixes #106