### PR TITLE
fix(trail): compute and record config_hash on every entry (closes #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **`migrate --batch-size` validation** — non-positive batch sizes now fail with
   a clear CLI error instead of crashing (`0`) or silently migrating zero records
   while reporting `PASS` (`-1`) (#106)
+- **`TrailRecord.config_hash` never populated** — `ContextTrail` now computes a
+  stable hash of its governance configuration (required fields, freshness
+  settings, active policies) and records it on every entry, so a reviewer can
+  tell whether governance settings changed mid-trail. Existing chains are
+  unaffected — `config_hash` is not part of the hash chain (#103)
 
 ## [1.0.1] - 2026-07-25
 

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from provena.exporters.otel import OTelExporter
-from provena.hasher import GENESIS_HASH, ChainHasher
+from provena.hasher import GENESIS_HASH, ChainHasher, content_hash
 from provena.models import (
     ChainVerdict,
     ContextEntry,
@@ -163,6 +163,7 @@ class ContextTrail:
 
         last = self._backend.get_last()
         self._previous_hash: str = last["chain_hash"] if last else GENESIS_HASH
+        self._config_hash = self._compute_config_hash(temporal_detection)
 
     def _apply_config(self, config: dict[str, Any]) -> None:
         storage = config.get("storage", {})
@@ -194,9 +195,10 @@ class ContextTrail:
         self._validator = ProvenanceValidator(
             required_fields=provenance.get("required_fields")
         )
+        temporal_detection = freshness.get("temporal_detection", True)
         self._freshness = FreshnessChecker(
             max_age_days=max_age,
-            temporal_detection=freshness.get("temporal_detection", True),
+            temporal_detection=temporal_detection,
         )
         self._otel = OTelExporter(
             enabled=otel.get("enabled", False),
@@ -234,6 +236,7 @@ class ContextTrail:
 
         last = self._backend.get_last()
         self._previous_hash = str(last["chain_hash"]) if last else GENESIS_HASH
+        self._config_hash = self._compute_config_hash(temporal_detection)
 
     def _update_signing_policies(self) -> None:
         from provena.policy import require_signing
@@ -250,6 +253,37 @@ class ContextTrail:
             else:
                 updated.append(policy)
         self._policy_engine = PolicyEngine(list(updated))
+
+    def _compute_config_hash(self, temporal_detection: bool) -> str:
+        """Hash the governance settings in effect for this trail.
+
+        Recorded on every entry so a reviewer can tell whether governance
+        settings changed partway through a trail. Settings are read back from
+        the constructed validators rather than from the raw arguments, so a
+        trail configured with the default required fields explicitly hashes
+        the same as one that left them unset. ``temporal_detection`` is passed
+        in because ``FreshnessChecker`` does not expose it.
+
+        Only stable policy identity is included — the name and enforcement
+        level. The ``Policy.check`` callable is deliberately excluded, since
+        its repr embeds a memory address and would change the hash on every
+        process.
+
+        Args:
+            temporal_detection: Whether regex temporal detection is enabled.
+
+        Returns:
+            A SHA-256 hex digest of the active governance configuration.
+        """
+        payload = {
+            "required_fields": sorted(self._validator.required_fields),
+            "max_age_days": self._freshness.max_age_days,
+            "temporal_detection": temporal_detection,
+            "policies": sorted(
+                [p.name, p.enforcement.value] for p in self._policy_engine.policies
+            ),
+        }
+        return content_hash(json.dumps(payload, sort_keys=True).encode("utf-8"))
 
     @property
     def error_count(self) -> int:
@@ -344,6 +378,7 @@ class ContextTrail:
                 "freshness_status": fresh_result.status,
                 "chain_hash": chain_hash,
                 "previous_hash": prev_hash,
+                "config_hash": self._config_hash,
                 "metadata_json": json.dumps(entry.metadata),
                 "content_type": entry.content_type,
                 "truncated": entry.truncated,
@@ -363,6 +398,7 @@ class ContextTrail:
             freshness_result=fresh_result,
             chain_hash=chain_hash,
             previous_hash=prev_hash,
+            config_hash=self._config_hash,
         )
 
         self._emit_otel(trail_record)

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from provena.models import ContextSource, ProvenanceMetadata
+from provena.policy import freshness_check
 from provena.trail import ContextTrail
 
 
@@ -762,6 +763,63 @@ class TestRecordCountAndLastRecord:
         last = memory_trail.last_record
         assert last is not None
         assert last["source"] == "tool"
+
+
+class TestContextTrailConfigHash:
+    def test_config_hash_is_recorded(self, memory_trail):
+        # config_hash was documented, stored, and plumbed through to_dict(),
+        # but never computed — every record was written with "".
+        record = memory_trail.log("data", source="retriever")
+        stored = memory_trail.query()[0]
+
+        assert record.config_hash != ""
+        assert stored["config_hash"] == record.config_hash
+
+    @pytest.mark.parametrize(
+        "governance_change",
+        [
+            {"max_age_days": 30},
+            {"required_fields": ["source_url"]},
+            {"temporal_detection": False},
+            {"policies": [freshness_check(status="STALE")]},
+        ],
+    )
+    def test_config_hash_changes_with_governance_config(self, governance_change):
+        # The whole point of the field: a reviewer can tell that governance
+        # settings changed partway through a trail.
+        baseline = ContextTrail(backend="memory")
+        changed = ContextTrail(backend="memory", **governance_change)
+
+        assert changed._config_hash != baseline._config_hash
+
+    def test_config_hash_is_stable_across_instances(self):
+        # A hash that varies run to run would be useless for comparison, so
+        # policies are sorted and only their stable identity is included —
+        # never the Policy.check callable, whose repr embeds a memory address.
+        first = ContextTrail(backend="memory", max_age_days=30)
+        second = ContextTrail(backend="memory", max_age_days=30)
+
+        assert first._config_hash == second._config_hash
+
+    def test_config_hash_matches_across_config_paths(self):
+        # ContextTrail has two config paths — kwargs and config=. Equivalent
+        # settings must hash identically, or the field would appear to change
+        # merely because a trail was constructed differently.
+        from_kwargs = ContextTrail(
+            backend="memory",
+            required_fields=["source_url", "created_at"],
+            max_age_days=30,
+            temporal_detection=False,
+        )
+        from_config = ContextTrail(
+            config={
+                "storage": {"backend": "memory"},
+                "provenance": {"required_fields": ["source_url", "created_at"]},
+                "freshness": {"max_age_days": 30, "temporal_detection": False},
+            }
+        )
+
+        assert from_kwargs._config_hash == from_config._config_hash
 
 
 class TestDisabledMode:


### PR DESCRIPTION
## What does this PR do?

`TrailRecord.config_hash` was documented as "Hash of the trail configuration at recording time",
had a dedicated column in both storage backends, and was threaded through `to_dict()` — but
`ContextTrail` never computed it, so every record ever written had `config_hash == ""`.

`ContextTrail` now computes a stable hash of its governance configuration once at construction
and records it on every entry.

**What goes into the hash** - the four settings named in the issue: `required_fields`,
`max_age_days`, `temporal_detection`, and active policies. For policies only the stable identity
is included (name + enforcement level); the `Policy.check` callable is deliberately excluded,
since its repr embeds a memory address and would change the hash on every process.

**Settings are read back from the constructed validators**, not from the raw arguments. This
matters because `ContextTrail` has two config paths - `__init__` kwargs and `_apply_config`
(`config=` dict / TOML / YAML). Hashing raw inputs would make
`ContextTrail(required_fields=["source_url", "created_at"])` hash differently from
`ContextTrail()`, even though `ProvenanceValidator` resolves both to the same effective config.
There's a test pinning the two paths to the same hash.

`temporal_detection` is passed into the helper rather than read back, because `FreshnessChecker`
doesn't expose it and adding a public property felt like unnecessary API surface for this fix.

### Existing trails are unaffected

`config_hash` is **not** an input to the hash chain - `ChainHasher.compute_chain_hash()` takes
only `previous_hash`, `content_hash`, `source` and `timestamp`, and `verify_chain()` recomputes
from exactly those. Both backends already declare the column as `TEXT NOT NULL DEFAULT ''`, so
there is no schema change and no migration.

Verified against a database written before this change: the legacy records keep `config_hash == ""`,
the chain still verifies, and appending new records to that same trail leaves it intact - a trail
containing both old and new records verifies fine.

`TrailRecord` is also constructed with `config_hash` so the returned object matches the stored row.
The issue only mentions the internal `record_data` dict, but `TrailRecord.to_dict()` exposes the
field, and without this `trail.log(...).config_hash` would still report `""`. Happy to drop that
line if you'd rather keep the change strictly to what was written.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

## Related Issues

Fixes #103
