### PR TITLE
feat(cli): add --provenance-status and --freshness-status to audit (c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **`provena audit` gains `--provenance-status` and `--freshness-status`
+  filters**, exposing the `trail.query()` filters that were already supported
+  by the API. Values are case-insensitive, and an unrecognized status is
+  rejected with a clear error rather than quietly matching no records (#85)
+
 ## [1.1.0] - 2026-08-23
 
 ### Added

--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -84,6 +84,18 @@ def _open_trail(ctx: click.Context) -> tuple[ContextTrail, str]:
 @cli.command()
 @click.option("--source", "-s", default=None, help="Filter by source type.")
 @click.option(
+    "--provenance-status",
+    default=None,
+    type=click.Choice(["VALID", "MISSING", "INCOMPLETE"], case_sensitive=False),
+    help="Filter by provenance validation status.",
+)
+@click.option(
+    "--freshness-status",
+    default=None,
+    type=click.Choice(["FRESH", "STALE", "UNKNOWN"], case_sensitive=False),
+    help="Filter by freshness check status.",
+)
+@click.option(
     "--limit",
     "-n",
     default=20,
@@ -116,6 +128,8 @@ def _open_trail(ctx: click.Context) -> tuple[ContextTrail, str]:
 def audit(
     ctx: click.Context,
     source: str | None,
+    provenance_status: str | None,
+    freshness_status: str | None,
     limit: int,
     start: datetime | None,
     end: datetime | None,
@@ -124,7 +138,14 @@ def audit(
     """Query the context governance audit log."""
     trail, _ = _open_trail(ctx)
     try:
-        records = trail.query(source=source, limit=limit, start=start, end=end)
+        records = trail.query(
+            source=source,
+            provenance_status=provenance_status,
+            freshness_status=freshness_status,
+            limit=limit,
+            start=start,
+            end=end,
+        )
 
         if not records:
             click.echo("No records found.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,11 +6,13 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
 
 import pytest
 from click.testing import CliRunner
 
 from provena.cli.main import cli
+from provena.models import ProvenanceMetadata
 from provena.trail import ContextTrail
 
 
@@ -127,6 +129,149 @@ class TestCLIAudit:
             )
             assert result.exit_code != 0
             assert "Invalid value for '--limit'" in result.output
+        finally:
+            os.unlink(db_path)
+
+    def _governance_db(self) -> str:
+        """Trail with one record per provenance status.
+
+        No provenance -> MISSING, source_url only -> INCOMPLETE, and both
+        required fields -> VALID. None of the three carry a usable timestamp
+        except the VALID one, which is created now and so reads as FRESH.
+        """
+        db_path = _create_trail_db(0)
+        trail = ContextTrail(storage_path=db_path)
+        trail.log("ungoverned", source="retriever")
+        trail.log(
+            "partial",
+            source="retriever",
+            provenance=ProvenanceMetadata(source_url="https://example.com/a"),
+        )
+        trail.log(
+            "governed",
+            source="retriever",
+            provenance=ProvenanceMetadata(
+                source_url="https://example.com/b",
+                created_at=datetime.now(timezone.utc),
+            ),
+        )
+        trail.close()
+        return db_path
+
+    def test_audit_filter_by_provenance_status(self):
+        db_path = self._governance_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "audit",
+                    "--provenance-status",
+                    "MISSING",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 1
+            assert data[0]["provenance_status"] == "MISSING"
+        finally:
+            os.unlink(db_path)
+
+    def test_audit_filter_by_freshness_status(self):
+        db_path = self._governance_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "audit",
+                    "--freshness-status",
+                    "FRESH",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 1
+            assert data[0]["freshness_status"] == "FRESH"
+        finally:
+            os.unlink(db_path)
+
+    def test_audit_status_filters_are_case_insensitive(self):
+        # Stored statuses are uppercase and the backend matches exactly, so a
+        # lowercase value would silently return nothing without normalization.
+        db_path = self._governance_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "audit",
+                    "--provenance-status",
+                    "missing",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 1
+            assert data[0]["provenance_status"] == "MISSING"
+        finally:
+            os.unlink(db_path)
+
+    def test_audit_combines_status_filters(self):
+        db_path = self._governance_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "audit",
+                    "--provenance-status",
+                    "VALID",
+                    "--freshness-status",
+                    "FRESH",
+                    "--format",
+                    "json",
+                ],
+            )
+            assert result.exit_code == 0
+            data = json.loads(result.output)
+            assert len(data) == 1
+            assert data[0]["provenance_status"] == "VALID"
+            assert data[0]["freshness_status"] == "FRESH"
+        finally:
+            os.unlink(db_path)
+
+    @pytest.mark.parametrize(
+        ("option", "bad_value"),
+        [
+            ("--provenance-status", "MISSNG"),
+            ("--freshness-status", "STALLE"),
+        ],
+    )
+    def test_audit_rejects_unknown_status(self, option, bad_value):
+        # A typo must not look like a clean audit: without validation the
+        # backend matches nothing and the CLI prints "No records found."
+        db_path = self._governance_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--db", db_path, "audit", option, bad_value])
+            assert result.exit_code != 0
+            assert f"Invalid value for '{option}'" in result.output
+            assert "No records found" not in result.output
         finally:
             os.unlink(db_path)
 


### PR DESCRIPTION
## What does this PR do?

Adds `--provenance-status` and `--freshness-status` to `provena audit`, exposing the
`trail.query()` filters that the API already supported:

```
provena audit --provenance-status MISSING        # all ungoverned context
provena audit --provenance-status VALID --freshness-status STALE
```

### One deviation from the issue, and why

The issue suggested plain string options. I used `click.Choice` instead, matching the
`--format` option already on this command.

The reason is that the backend matches these statuses exactly and case-sensitively. With a
plain string, `provena audit --provenance-status missing` returns zero rows and the CLI prints
`No records found.` So does a typo like `MISSNG`. On an audit tool, "no records found" reads as
"your data is clean", which is the opposite of what a mistyped filter actually means.

With `click.Choice`, a bad value is rejected up front:

```
Error: Invalid value for '--provenance-status': 'MISSNG' is not one of 'valid', 'missing', 'incomplete'.
```

`case_sensitive=False` means lowercase input still works: Click normalizes `missing` to
`MISSING` before it reaches `query()`, so the filter matches. Operators can type either case,
but genuine typos are caught.

Trade-off worth naming: with `case_sensitive=False`, Click renders the choices lowercase in
`--help` and in error text, even though the stored values are uppercase. Both cases work, so
this is cosmetic, but happy to add an explicit `metavar` to force uppercase display if you'd
prefer it.

If you'd rather keep it exactly as written in the issue, swapping `click.Choice` for a plain
option is a two-line change.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

Six new tests in `TestCLIAudit`: each filter independently, the two combined, case-insensitive
input, and a parametrized check that an unknown status errors rather than printing
`No records found.` All six fail without the change.

## Related Issues

Fixes #85