### PR TITLE
feat(cli): add --source filter to summary command (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   filters**, exposing the `trail.query()` filters that were already supported
   by the API. Values are case-insensitive, and an unrecognized status is
   rejected with a clear error rather than quietly matching no records (#85)
+- **`provena summary` gains a `--source/-s` filter**, matching the option
+  already on `provena audit`, so a multi-source pipeline can be inspected one
+  source at a time. Counts are paged rather than taken from a single
+  `query()` call, so they stay accurate past the default 100-row cap (#75)
 
 ## [1.1.0] - 2026-08-23
 

--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -299,12 +299,13 @@ def retain(
 
 
 @cli.command()
+@click.option("--source", "-s", default=None, help="Filter by source type.")
 @click.pass_context
-def summary(ctx: click.Context) -> None:
+def summary(ctx: click.Context, source: str | None) -> None:
     """Show a quick summary of the audit trail."""
     trail, _ = _open_trail(ctx)
     try:
-        s = trail.summary()
+        s = _summarize_source(trail, source) if source else trail.summary()
         h = trail.health()
 
         click.echo(f"Records:    {s['total']}")
@@ -450,6 +451,54 @@ def migrate(
     finally:
         src.close()
         dst.close()
+
+
+def _summarize_source(trail: ContextTrail, source: str) -> dict[str, Any]:
+    """Build a ``trail.summary()``-shaped dict for a single source.
+
+    ``ContextTrail.summary()`` aggregates the whole trail and takes no source
+    filter, so the records are pulled through ``query()`` instead. That call
+    caps at 100 rows by default, so it is paged the same way
+    ``TrailAggregator.detect_gaps()`` pages — otherwise the counts would stop
+    at the first page and silently under-report.
+
+    Args:
+        trail: The open trail to summarize.
+        source: Source type to restrict the summary to.
+
+    Returns:
+        A dict with the same keys as ``ContextTrail.summary()``.
+    """
+    prov_counts: dict[str, int] = {}
+    fresh_counts: dict[str, int] = {}
+    source_counts: dict[str, int] = {}
+    total = 0
+
+    offset = 0
+    batch_size = 1000
+    while True:
+        records = trail.query(source=source, limit=batch_size, offset=offset)
+        if not records:
+            break
+        for r in records:
+            total += 1
+            status = r.get("provenance_status", "MISSING")
+            prov_counts[status] = prov_counts.get(status, 0) + 1
+            fstatus = r.get("freshness_status", "UNKNOWN")
+            fresh_counts[fstatus] = fresh_counts.get(fstatus, 0) + 1
+            src = r.get("source", "unknown")
+            source_counts[src] = source_counts.get(src, 0) + 1
+        if len(records) < batch_size:
+            break
+        offset += len(records)
+
+    return {
+        "total": total,
+        "provenance": prov_counts,
+        "freshness": fresh_counts,
+        "sources": source_counts,
+        "signed": trail.is_signed,
+    }
 
 
 def _open_backend(path: str) -> Any:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -532,6 +532,80 @@ class TestCLISummary:
         result = runner.invoke(cli, ["--db", "/nonexistent/path.db", "summary"])
         assert result.exit_code != 0
 
+    def _mixed_source_db(self, retriever: int = 3, tool: int = 2) -> str:
+        db_path = _create_trail_db(0)
+        trail = ContextTrail(storage_path=db_path)
+        for i in range(retriever):
+            trail.log(f"ret {i}", source="retriever")
+        for i in range(tool):
+            trail.log(f"tool {i}", source="tool:api")
+        trail.close()
+        return db_path
+
+    def test_summary_filter_by_source(self):
+        db_path = self._mixed_source_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["--db", db_path, "summary", "--source", "retriever"]
+            )
+            assert result.exit_code == 0
+            assert "Records:    3" in result.output
+            assert "retriever" in result.output
+            assert "tool" not in result.output
+        finally:
+            os.unlink(db_path)
+
+    def test_summary_filter_by_source_short_flag(self):
+        db_path = self._mixed_source_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--db", db_path, "summary", "-s", "tool"])
+            assert result.exit_code == 0
+            assert "Records:    2" in result.output
+            assert "retriever" not in result.output
+        finally:
+            os.unlink(db_path)
+
+    def test_summary_without_source_is_unchanged(self):
+        db_path = self._mixed_source_db()
+        try:
+            runner = CliRunner()
+            unfiltered = runner.invoke(cli, ["--db", db_path, "summary"])
+            assert unfiltered.exit_code == 0
+            assert "Records:    5" in unfiltered.output
+            assert "retriever" in unfiltered.output
+            assert "tool" in unfiltered.output
+        finally:
+            os.unlink(db_path)
+
+    def test_summary_filter_counts_beyond_one_query_page(self):
+        # trail.query() caps at 100 rows by default, so a naive implementation
+        # would report 100 here instead of 150. The filtered path pages.
+        db_path = self._mixed_source_db(retriever=150, tool=20)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["--db", db_path, "summary", "--source", "retriever"]
+            )
+            assert result.exit_code == 0
+            assert "Records:    150" in result.output
+            assert "MISSING      150" in result.output
+        finally:
+            os.unlink(db_path)
+
+    def test_summary_filter_unknown_source_is_empty(self):
+        db_path = self._mixed_source_db()
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["--db", db_path, "summary", "--source", "nope"]
+            )
+            assert result.exit_code == 0
+            assert "Records:    0" in result.output
+        finally:
+            os.unlink(db_path)
+
 
 class TestCLIVersion:
     def test_version(self):


### PR DESCRIPTION
## What does this PR do?

Adds `--source/-s` to `provena summary`, matching the option already on `provena audit`:

```
provena summary --source retriever
provena summary -s tool
```

Implemented as the issue describes: filter through `trail.query(source=...)` and compute the
counts in the CLI, since `trail.summary()` takes no source filter.

### One thing worth flagging: `query()` caps at 100 rows

`trail.query()` defaults to `limit=100`, so the direct reading of the issue

```python
records = trail.query(source=source)
```

reports `Records: 100` for a trail holding 150 retriever records. A summary that silently
under-counts seemed worse than the missing feature, so the fetch is paged using the same idiom
`TrailAggregator.detect_gaps()` uses (batch of 1000, break on a short page, `offset += len(records)`).
There's a test covering the 150-record case specifically.

### Unfiltered output is structurally unchanged

`_summarize_source()` returns a dict with the same keys as `ContextTrail.summary()`, so the
command body is a single line:

```python
s = _summarize_source(trail, source) if source else trail.summary()
```

The printing block below it is untouched, and without `--source` the code path is exactly what
it was before. The counting loop mirrors `ContextTrail.summary()` including its `.get()`
defaults, so filtered and unfiltered totals agree.

No public API changed; everything is contained in `cli/main.py`.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

Five new tests in `TestCLISummary`: `--source` filtering, the `-s` short flag, the >100-record
paging case, an unknown source returning zero, and a guard that unfiltered output still shows
all sources. Four of the five fail without the change; the fifth is the unchanged-behavior
guard the issue asked for, so it passes either way by design.

## Related Issues

Fixes #75
