### PR TITLE
docs: clarify what VALID does and does not check

### DIFF
--- a/docs/guide/provenance.md
+++ b/docs/guide/provenance.md
@@ -72,6 +72,21 @@ print(summary["provenance"])
 # {'MISSING': 1, 'INCOMPLETE': 1, 'VALID': 1}
 ```
 
+!!! note "VALID means present, not verified"
+    A `VALID` verdict only confirms that the required fields are present and
+    non-empty. It doesn't fetch `source_url` or check `created_at` against
+    when the entry was actually logged, so a plausible but fabricated value
+    passes just as well as a real one. This is deliberate: Provena is an
+    audit trail, and it records what was declared, not whether the
+    declaration is true.
+
+    For stricter checks, add a rule to the policy engine's
+    `provenance_check()` hook, for example a domain allowlist or a
+    timestamp-recency check. The hook runs at log time with full access to
+    the record, but a `BLOCK`-level `DENY` fires after the record is
+    persisted and the chain has advanced, so the declaration still ends up
+    in the trail.
+
 ## Default Required Fields
 
 By default, Provena requires two fields for a VALID verdict:


### PR DESCRIPTION
This follows from #137. I asked whether VALID corroborates provenance, and the answer was no: it just checks that source_url and created_at are present and non-empty. That's a reasonable design (Provena records what was declared, not whether it's true), but it wasn't written down anywhere, so I added a short note to the provenance guide.

I checked this against validators/provenance.py (presence and non-empty checks only, no network call) and against policy.py plus the _log_internal flow in trail.py, which confirmed that a BLOCK-level DENY from provenance_check() runs after the record is already persisted and the chain hash has already advanced.

Docs-only change, ran mkdocs build --strict locally with no errors.
