### PR TITLE
fix(deps): include postgres, mcp and pdf in the all extra (closes #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   CI/CD pipelines and shell scripts, showing record count, provenance/freshness
   breakdowns, chain integrity, and signing status in a parseable format (#76)
 
+### Fixed
+
+- **`provena[all]` now installs what the README says it does** — the extra
+  resolved to only `yaml,cli,otel`, silently omitting the `postgres`, `mcp` and
+  `pdf` extras the README already documented it as including. Framework
+  adapters remain deliberately excluded (#71)
+
 ## [1.1.0] - 2026-08-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ openai-agents = ["openai-agents>=0.1"]
 google-adk = ["google-adk>=1.0"]
 mcp = ["fastmcp>=2.0"]
 pdf = ["fpdf2>=2.7"]
-all = ["provena[yaml,cli,otel]"]
+all = ["provena[yaml,cli,otel,postgres,mcp,pdf]"]
 docs = [
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.25",


### PR DESCRIPTION
## What does this PR do?

`provena[all]` resolved to only `yaml,cli,otel`, silently omitting `postgres`, `mcp` and `pdf`.

Worth noting: `README.md` line 58 already documents the intended set.

```
pip install provena[all]           # core + cli + otel + postgres + mcp + pdf + yaml
```

So this is `pyproject.toml` drifting out of sync with documented behavior, not an open question
about what `all` ought to contain. The change makes the two agree exactly.

```diff
-all = ["provena[yaml,cli,otel]"]
+all = ["provena[yaml,cli,otel,postgres,mcp,pdf]"]
```

Framework adapters (`langchain`, `llamaindex`, `crewai`, `autogen`, `openai-agents`,
`google-adk`) stay excluded, per the note in the issue and consistent with the README, since
pulling six agent frameworks into one install would be heavy and they conflict with each other.

### Verification

Installed metadata before the change, filtered to `extra == 'all'`:

```
click>=8.0; extra == 'all'
opentelemetry-api>=1.20; extra == 'all'
pyyaml>=6.0; extra == 'all'
rich>=13.0; extra == 'all'
```

And after:

```
click>=8.0; extra == 'all'
fastmcp>=2.0; extra == 'all'
fpdf2>=2.7; extra == 'all'
opentelemetry-api>=1.20; extra == 'all'
psycopg[pool]>=3.1; extra == 'all'
pyyaml>=6.0; extra == 'all'
rich>=13.0; extra == 'all'
```

`pip install -e ".[all]"` resolves cleanly, with `psycopg` and `psycopg-pool` as the newly
pulled-in packages. The full suite still passes (505 passed, 22 skipped), and ruff and mypy
are clean.

## Checklist

- [ ] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

No test added: this is packaging metadata rather than runtime code, and the only way to assert
it would be a test that reads `importlib.metadata` and pins the extras list, which would need
editing every time an extra is added. Verified by metadata inspection instead, shown above.
Happy to add such a test if you'd want the regression guard.

## Related Issues

Fixes #71
