### PR TITLE
fix: log policy evaluation errors at warning level

### DIFF
--- a/src/provena/policy.py
+++ b/src/provena/policy.py
@@ -133,7 +133,7 @@ class PolicyEngine:
             try:
                 passed = policy.check(record)
             except Exception:
-                _logger.debug(
+                _logger.warning(
                     "Policy '%s' raised during evaluation", policy.name, exc_info=True
                 )
                 passed = False

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -165,16 +165,29 @@ class TestPolicyEngine:
         engine = PolicyEngine()
         assert isinstance(engine.policies, tuple)
 
-    def test_check_exception_treated_as_failure(self, memory_trail):
+    def test_check_exception_treated_as_failure(self, memory_trail, caplog):
         def bad_check(r):
             raise RuntimeError("boom")
 
         policy = Policy("bad", bad_check, EnforcementLevel.BLOCK)
         engine = PolicyEngine([policy])
         record = memory_trail.log("test", source="retriever")
-        evaluation = engine.evaluate(record)
+
+        with caplog.at_level("WARNING", logger="provena.policy"):
+            evaluation = engine.evaluate(record)
+
         assert evaluation.decision == "DENY"
         assert not evaluation.results[0].passed
+
+        matching_records = [
+            record
+            for record in caplog.records
+            if "Policy 'bad' raised during evaluation" in record.message
+        ]
+
+        assert len(matching_records) == 1
+        assert "Policy 'bad' raised during evaluation" in caplog.text
+        assert "boom" in caplog.text
 
 
 class TestPolicyEngineFromConfig:


### PR DESCRIPTION
## What changed

Changed policy evaluation exception logging from `DEBUG` to `WARNING`.

Strengthened the existing policy exception test to verify that:

- A policy exception is still treated as a failed check.
- A BLOCK policy still results in `DENY`.
- The exception is logged at `WARNING`.
- The exception message is preserved.

## Related Issue

Closes #152

## Tests

- `pytest tests/test_policy.py -q`
- `pytest -q`
- `git diff --check`

Full test suite: `498 passed, 33 skipped`