### PR TITLE
fix(freshness): normalize naive now override to UTC (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`FreshnessChecker.check()` accepts a naive `now` override**, normalizing it to UTC-aware like `created_at`, instead of raising `TypeError: can't subtract offset-naive and offset-aware datetimes` (#147)
 - **`provena[all]` now installs what the README says it does** — the extra
   resolved to only `yaml,cli,otel`, silently omitting the `postgres`, `mcp` and
   `pdf` extras the README already documented it as including. Framework

--- a/src/provena/validators/freshness.py
+++ b/src/provena/validators/freshness.py
@@ -126,6 +126,11 @@ class FreshnessChecker:
             A FreshnessResult with status FRESH, STALE, or UNKNOWN.
         """
         reference = now or datetime.now(timezone.utc)
+        # Normalize a caller-supplied naive `now` to UTC-aware, matching how
+        # created_at is normalized below. Without this, subtracting a naive
+        # `now` from an aware created_at raises an opaque TypeError.
+        if reference.tzinfo is None:
+            reference = reference.replace(tzinfo=timezone.utc)
 
         result = self._check_metadata(entry, reference)
         if result is not None:

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -75,6 +75,20 @@ class TestFreshnessCheckerMetadata:
         result = checker.check(entry, now=now)
         assert result.status == "FRESH"
 
+    def test_naive_now_override_treated_as_utc(self):
+        # Regression for #147: passing a naive `now` override previously
+        # raised "can't subtract offset-naive and offset-aware datetimes"
+        # because created_at is normalized to UTC-aware internally. A naive
+        # `now` must be normalized the same way instead of crashing.
+        aware_created = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        naive_now = datetime(2025, 1, 11)  # 10 days later, no tzinfo
+        checker = FreshnessChecker(max_age_days=90)
+        entry = _entry(created_at=aware_created)
+
+        result = checker.check(entry, now=naive_now)
+        assert result.status == "FRESH"
+        assert "10 days" in result.details
+
     def test_no_provenance_returns_unknown(self):
         checker = FreshnessChecker(max_age_days=90)
         entry = _entry()


### PR DESCRIPTION
## Summary
`FreshnessChecker.check()` accepts a caller-supplied `now` override but never checks that it is timezone-aware. `created_at` is always normalized to UTC-aware internally, so subtracting a naive `now` raises `TypeError: can't subtract offset-naive and offset-aware datetimes`. The `now` parameter exists mainly for tests and backfill, where `tzinfo` is easy to omit.

## Change
Normalize `now` the same way `created_at` is normalized — assume UTC when it is naive — per the issue's Expected behavior (first option). One guard at the top of `check()`.

## Testing
Added `TestFreshnessCheckerMetadata::test_naive_now_override_treated_as_utc` (passes a naive `now` against an aware `created_at`, asserts FRESH). Fails on `main`, passes with the fix.

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated

Closes #147
