### PR TITLE
fix(storage): acquire lock in InMemoryBackend.get/get_last (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`InMemoryBackend.get()` and `get_last()` now hold the backend lock** when reading `_records`, matching every other method on the backend and closing a TOCTOU race that could raise `IndexError` under concurrent `append()` (#145)
 - **`provena[all]` now installs what the README says it does** — the extra
   resolved to only `yaml,cli,otel`, silently omitting the `postgres`, `mcp` and
   `pdf` extras the README already documented it as including. Framework

--- a/src/provena/storage.py
+++ b/src/provena/storage.py
@@ -298,13 +298,15 @@ class InMemoryBackend:
 
     def get(self, record_id: int) -> dict[str, Any] | None:
         """Retrieve a record by ID, or None if not found."""
-        if 1 <= record_id <= len(self._records):
-            return {**self._records[record_id - 1]}
-        return None
+        with self._lock:
+            if 1 <= record_id <= len(self._records):
+                return {**self._records[record_id - 1]}
+            return None
 
     def get_last(self) -> dict[str, Any] | None:
         """Retrieve the most recently appended record, or None."""
-        return {**self._records[-1]} if self._records else None
+        with self._lock:
+            return {**self._records[-1]} if self._records else None
 
     def count(self) -> int:
         """Return the total number of records."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -157,6 +157,32 @@ class TestInMemoryBackend:
         assert id2 == 2
         assert id3 == 3
 
+    def test_get_and_get_last_hold_lock(self, memory_backend):
+        # Regression for #145: get() and get_last() previously read
+        # self._records without acquiring self._lock, unlike every other
+        # method on the backend (TOCTOU race under concurrent append).
+        # Wrap the real lock and assert both methods enter it exactly once.
+        memory_backend.append(_make_record())
+        real_lock = memory_backend._lock
+
+        class _TrackingLock:
+            def __init__(self) -> None:
+                self.enters = 0
+
+            def __enter__(self):
+                self.enters += 1
+                return real_lock.__enter__()
+
+            def __exit__(self, *exc):
+                return real_lock.__exit__(*exc)
+
+        tracker = _TrackingLock()
+        memory_backend._lock = tracker
+
+        assert memory_backend.get(1) is not None
+        assert memory_backend.get_last() is not None
+        assert tracker.enters == 2
+
 
 class TestSQLiteBackend:
     def test_append_and_get(self, sqlite_backend):


### PR DESCRIPTION
## Summary
`InMemoryBackend.get()` and `get_last()` read `self._records` without holding `self._lock`, unlike every other method on the backend (`append`, `count`, `query`, `all_records`, `add_annotation`, `get_annotations`). This is a TOCTOU race: `get_last()`'s `if self._records` / `self._records[-1]` can raise `IndexError` under a concurrent `append()`, and on non-CPython runtimes the read can observe a partially-initialized dict.

## Change
Wrap both reads in `with self._lock:`, exactly as the issue's Expected behavior describes.

## Testing
Added `TestInMemoryBackend::test_get_and_get_last_hold_lock`, which wraps the real lock and asserts both methods enter it. Fails on `main`, passes with the fix.

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated

Closes #145
