### PR TITLE
fix(trail): return ChainVerdict for null chain_hash in verify_chain (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`verify_chain()` returns `ChainVerdict(intact=False)` for a `None`/malformed `chain_hash`** instead of raising `TypeError` out of `hmac.compare_digest`, so corrupted or hand-edited records are reported as broken links rather than crashing the audit path (#146)
 - **`provena[all]` now installs what the README says it does** — the extra
   resolved to only `yaml,cli,otel`, silently omitting the `postgres`, `mcp` and
   `pdf` extras the README already documented it as including. Framework

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -609,14 +609,22 @@ class ContextTrail:
                 source=record["source"],
                 timestamp=record["timestamp"],
             )
-            if not hmac.compare_digest(expected, record["chain_hash"]):
+            stored_hash = record.get("chain_hash")
+            if not isinstance(stored_hash, str) or not hmac.compare_digest(
+                expected, stored_hash
+            ):
                 return ChainVerdict(
                     intact=False,
                     total_records=len(records),
                     broken_at=record["id"],
-                    details=f"Chain broken at record {record['id']}",
+                    details=(
+                        f"Chain broken at record {record['id']} — "
+                        f"chain_hash is {stored_hash!r}"
+                        if not isinstance(stored_hash, str)
+                        else f"Chain broken at record {record['id']}"
+                    ),
                 )
-            previous_hash = record["chain_hash"]
+            previous_hash = stored_hash
 
         return ChainVerdict(
             intact=True,

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -115,6 +115,20 @@ class TestContextTrailVerify:
         finally:
             os.unlink(db_path)
 
+    def test_verify_null_chain_hash_returns_verdict(self, memory_trail):
+        # Regression for #146: a None/malformed chain_hash must be reported
+        # as a broken link via ChainVerdict, not raise TypeError out of
+        # hmac.compare_digest (which requires both args to be str).
+        for i in range(3):
+            memory_trail.log(f"entry_{i}", source="retriever")
+        memory_trail._backend._records[1]["chain_hash"] = None
+
+        verdict = memory_trail.verify_chain()
+        assert not verdict.intact
+        assert verdict.broken_at == 2
+        assert verdict.total_records == 3
+        assert "chain_hash" in verdict.details
+
     def test_verify_signed_chain_rejects_wrong_key(self):
         with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
             db_path = f.name


### PR DESCRIPTION
## Summary
`verify_chain()` calls `hmac.compare_digest(expected, record["chain_hash"])`. `compare_digest` requires both args to be the same type; `expected` is always `str`. A `None` (or otherwise non-str) `chain_hash` — a hand-inserted row or a backend bug — makes it raise `TypeError` instead of returning a verdict. That propagates uncaught, so the CLI `verify` command shows a traceback and programmatic callers get an exception where they expect a `ChainVerdict`.

## Change
Add a type guard before `compare_digest`, treating a non-str `chain_hash` as a broken link and returning `ChainVerdict(intact=False, ...)` with a `details` string that includes the offending value — matching the issue's Expected behavior.

## Testing
Added `TestContextTrailVerify::test_verify_null_chain_hash_returns_verdict` (corrupts a record's `chain_hash` to `None`, asserts `intact is False`, `broken_at`, and a `details` mentioning `chain_hash`). Fails on `main`, passes with the fix.

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated

Closes #146
