### PR TITLE
fix(cli): close trail in mcp serve via try/finally (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`provena mcp serve` now closes the trail on exit** — the server call is wrapped in `try/finally`, so the SQLite handle/WAL is checkpointed and the final buffer flush runs even if `configure()`/`create_server()` raise or `server.run()` returns (#148)
 - **`provena[all]` now installs what the README says it does** — the extra
   resolved to only `yaml,cli,otel`, silently omitting the `postgres`, `mcp` and
   `pdf` extras the README already documented it as including. Framework

--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -399,10 +399,12 @@ def serve(ctx: click.Context, db: str | None, transport: str) -> None:
     signing_key = ctx.parent.parent.obj.get("signing_key")  # type: ignore[union-attr]
 
     trail = ContextTrail(storage_path=db_path, signing_key=signing_key)
-    configure(trail)
-
-    server = create_server()
-    server.run(transport=transport)
+    try:
+        configure(trail)
+        server = create_server()
+        server.run(transport=transport)
+    finally:
+        trail.close()
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -745,3 +745,44 @@ class TestCLIStats:
             assert len(lines) == 1
         finally:
             os.unlink(db_path)
+
+
+class TestCLIMcpServe:
+    """Regression tests for #148: `mcp serve` must close the trail even when
+    configure()/create_server()/server.run() raise, and on normal shutdown."""
+
+    def _patch(self, monkeypatch, run_side_effect=None):
+        import provena.cli.main as main_mod
+        import provena.mcp_server as mcp_mod
+
+        closed = {"count": 0}
+
+        class _FakeTrail:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def close(self):
+                closed["count"] += 1
+
+        class _FakeServer:
+            def run(self, transport="stdio"):
+                if run_side_effect is not None:
+                    raise run_side_effect
+
+        monkeypatch.setattr(main_mod, "ContextTrail", _FakeTrail)
+        monkeypatch.setattr(mcp_mod, "configure", lambda trail: None)
+        monkeypatch.setattr(mcp_mod, "create_server", lambda: _FakeServer())
+        return closed
+
+    def test_serve_closes_trail_on_normal_return(self, monkeypatch):
+        closed = self._patch(monkeypatch)
+        result = CliRunner().invoke(cli, ["mcp", "serve"])
+        assert result.exit_code == 0
+        assert closed["count"] == 1
+
+    def test_serve_closes_trail_on_exception(self, monkeypatch):
+        closed = self._patch(monkeypatch, run_side_effect=RuntimeError("boom"))
+        result = CliRunner().invoke(cli, ["mcp", "serve"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, RuntimeError)
+        assert closed["count"] == 1


### PR DESCRIPTION
## Summary
`provena mcp serve` builds a `ContextTrail`, calls `configure()`, then `server.run()` with no `try/finally`. On normal shutdown (or if `configure()` / `create_server()` raise), `trail.close()` never runs — the SQLite handle/WAL is leaked without a final checkpoint (corruption risk on kill/crash) and buffered records are lost because `close()` triggers the final flush.

## Change
Wrap the server lifecycle in `try/finally: trail.close()`. Note: the issue's snippet puts `configure()` before the `try`, but its Summary explicitly calls out `configure()`/`create_server()` raising as a leak path, so the `try` here starts right after the trail is constructed to cover those too. Happy to narrow it to match the snippet exactly if you'd prefer.

## Testing
Added `TestCLIMcpServe` with two cases (normal return and `server.run()` raising), each asserting `trail.close()` is called exactly once. Both fail on `main`, pass with the fix.

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated

Closes #148
