### PR TITLE
fix(retention): page through all expired records, remove 10k cap (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`RetentionEngine` no longer silently caps at 10,000 expired records per run** — `find_expired()` pages through the full result set, so `preview()` and `execute()` act on every expired record instead of only the first batch (#102)
 - **`provena[all]` now installs what the README says it does** — the extra
   resolved to only `yaml,cli,otel`, silently omitting the `postgres`, `mcp` and
   `pdf` extras the README already documented it as including. Framework

--- a/src/provena/retention.py
+++ b/src/provena/retention.py
@@ -40,6 +40,11 @@ class RetentionEngine:
     supports export-before-delete for compliance archival.
     """
 
+    #: Page size used when scanning for expired records. Exposed as an
+    #: attribute (rather than a hardcoded literal) so tests can shrink it to
+    #: exercise the multi-batch pagination path without inserting 10k+ rows.
+    _QUERY_BATCH_SIZE = 10000
+
     def __init__(
         self,
         trail: Any,
@@ -76,8 +81,25 @@ class RetentionEngine:
         """
         reference = now or datetime.now(timezone.utc)
         cutoff = reference - timedelta(days=self._retention_days)
-        result: list[dict[str, Any]] = self._trail.query(end=cutoff, limit=10000)
-        return result
+
+        # Page through the full result set instead of taking only the first
+        # batch. A single limit=10000 query silently dropped every expired
+        # record past the 10,000th, producing a partial purge that reported
+        # success — unacceptable for a compliance retention engine. Records
+        # are only read here (deletion happens later), so offset paging over
+        # a stable snapshot is safe and complete.
+        batch = self._QUERY_BATCH_SIZE
+        expired: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            page: list[dict[str, Any]] = self._trail.query(
+                end=cutoff, limit=batch, offset=offset
+            )
+            expired.extend(page)
+            if len(page) < batch:
+                break
+            offset += batch
+        return expired
 
     def preview(self, now: datetime | None = None) -> dict[str, Any]:
         """Preview what a retention run would do without making changes.

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -140,3 +140,38 @@ class TestRetentionCLI:
         runner = CliRunner()
         result = runner.invoke(cli, ["retain", "--max-age", "30"])
         assert result.exit_code == 1
+
+
+class TestRetentionPagination:
+    """Regression tests for #102: retention must not silently cap at one
+    batch of expired records."""
+
+    def _old_trail(self, count: int):
+        trail = ContextTrail(backend="memory")
+        now = datetime.now(timezone.utc)
+        for i in range(count):
+            trail.log(f"old record {i}", source="retriever")
+        for record in trail._backend._records:
+            record["timestamp"] = (now - timedelta(days=400)).isoformat()
+        return trail
+
+    def test_find_expired_pages_beyond_one_batch(self):
+        trail = self._old_trail(7)
+        try:
+            engine = RetentionEngine(trail, retention_days=180)
+            engine._QUERY_BATCH_SIZE = 2  # smaller than the 7 expired records
+            expired = engine.find_expired()
+            assert len(expired) == 7
+            assert engine.preview()["would_delete"] == 7
+        finally:
+            trail.close()
+
+    def test_execute_purges_all_beyond_one_batch(self):
+        trail = self._old_trail(7)
+        try:
+            engine = RetentionEngine(trail, retention_days=180)
+            engine._QUERY_BATCH_SIZE = 2
+            result = engine.execute()
+            assert result.deleted == 7
+        finally:
+            trail.close()


### PR DESCRIPTION
## Summary
`RetentionEngine.find_expired()` hardcodes `limit=10000`. A trail with more than 10,000 records past the retention cutoff has only the first 10,000 purged, while `execute()` returns a `RetentionResult` indistinguishable from a complete run — a silent partial purge in a compliance engine whose purpose is deterministic, complete enforcement.

## Change
`find_expired()` now pages through the full result set with offset paging until a short page is returned, so both `preview()` and `execute()` act on every expired record. The page size is exposed as `RetentionEngine._QUERY_BATCH_SIZE` (default 10000) so it can be shrunk in tests. Records are only read during paging (deletion happens afterward), so paging over the snapshot is safe and complete.

## Testing
Added `TestRetentionPagination` with `_QUERY_BATCH_SIZE = 2` and 7 expired records: one test asserts `find_expired()`/`preview()` see all 7, another that `execute()` purges all 7 — exercising the multi-batch path, exactly the small-injected-limit approach the issue suggests.

Transparency note: because the pre-fix code has no batch seam and its real cap is 10,000, this test can't be made to fail on `main` without inserting 10k+ rows; it validates the new pagination path rather than reproducing the cap at N=7.

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated

Closes #102
