### PR TITLE
fix(trail): extract provenance per document for list results (closes #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`@trail.track` now extracts provenance per document** when the decorated
+  function returns a list. `_extract_provenance` ran on the list itself, which
+  has no `.metadata`, so every document in a retrieved batch was recorded with
+  `provenance_status=MISSING` and no freshness check, even when each document
+  carried its own `source` and `created_at`. A batch containing a stale
+  document now flags it `STALE` instead of hiding it behind a batch-wide
+  `UNKNOWN` (#149)
 - **`provena mcp serve` now closes the trail on exit** — the server call is wrapped in `try/finally`, so the SQLite handle/WAL is checkpointed and the final buffer flush runs even if `configure()`/`create_server()` raise or `server.run()` returns (#148)
 - **`verify_chain()` returns `ChainVerdict(intact=False)` for a `None`/malformed `chain_hash`** instead of raising `TypeError` out of `hmac.compare_digest`, so corrupted or hand-edited records are reported as broken links rather than crashing the audit path (#146)
 - **`InMemoryBackend.get()` and `get_last()` now hold the backend lock** when reading `_records`, matching every other method on the backend and closing a TOCTOU race that could raise `IndexError` under concurrent `append()` (#145)

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -513,8 +513,8 @@ class ContextTrail:
     ) -> None:
         try:
             items = self._extract_content(result, content_extractor)
-            provenance = self._extract_provenance(result)
-            for content in items:
+            provenances = self._extract_provenances(result, len(items))
+            for content, provenance in zip(items, provenances, strict=True):
                 self._log_internal(
                     content=content,
                     source=source,
@@ -566,6 +566,32 @@ class ContextTrail:
         if hasattr(item, "text"):
             return str(item.text)
         return str(item)
+
+    def _extract_provenances(
+        self, result: Any, count: int
+    ) -> list[ProvenanceMetadata | None]:
+        """Provenance for each content item extracted from ``result``.
+
+        A retriever returning ten Documents should record ten distinct
+        sources, so when ``result`` is a sequence that produced exactly one
+        content item per element, provenance is read from each element.
+
+        The counts fail to line up when a ``content_extractor`` reshapes the
+        result, or when the result is not a sequence. The mapping from item
+        back to element is unknown in those cases, so provenance is read from
+        ``result`` as a whole and shared across the items, which is what every
+        case did before per-element extraction was added.
+
+        Args:
+            result: The value returned by the tracked function.
+            count: Number of content items ``_extract_content`` produced.
+
+        Returns:
+            A list of exactly ``count`` provenance values, one per item.
+        """
+        if isinstance(result, (list, tuple)) and len(result) == count:
+            return [self._extract_provenance(item) for item in result]
+        return [self._extract_provenance(result)] * count
 
     def _extract_provenance(self, result: Any) -> ProvenanceMetadata | None:
         if hasattr(result, "metadata") and isinstance(result.metadata, dict):

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -233,6 +233,103 @@ class TestContextTrailTrack:
         assert doc.page_content == "LangChain document content"
         assert memory_trail.summary()["total"] == 1
 
+    class _Doc:
+        """Minimal stand-in for a LangChain/LlamaIndex Document."""
+
+        def __init__(self, text, metadata=None):
+            self.page_content = text
+            self.metadata = metadata or {}
+
+    def test_track_list_extracts_per_document_provenance(self, memory_trail):
+        # _extract_provenance used to run on the list itself. Lists have no
+        # .metadata, so every document in a retrieved batch was recorded as
+        # MISSING even when each carried its own source.
+        @memory_trail.track(source="retriever")
+        def search(query):
+            now = datetime.now(timezone.utc).isoformat()
+            return [
+                self._Doc("a", {"source": "https://example.com/a", "created_at": now}),
+                self._Doc("b", {"source": "https://example.com/b", "created_at": now}),
+            ]
+
+        search("test")
+        records = memory_trail.query()
+
+        assert len(records) == 2
+        assert [r["provenance_status"] for r in records] == ["VALID", "VALID"]
+        urls = [json.loads(r["provenance_json"])["source_url"] for r in records]
+        assert urls == ["https://example.com/a", "https://example.com/b"]
+
+    def test_track_list_runs_freshness_per_document(self, memory_trail):
+        # The point of per-document provenance: a stale document in a batch
+        # must be flagged, not hidden behind a batch-wide UNKNOWN.
+        fresh = datetime.now(timezone.utc)
+        stale = datetime.now(timezone.utc) - timedelta(days=400)
+
+        @memory_trail.track(source="retriever")
+        def search(query):
+            return [
+                self._Doc(
+                    "recent",
+                    {
+                        "source": "https://example.com/a",
+                        "created_at": fresh.isoformat(),
+                    },
+                ),
+                self._Doc(
+                    "old",
+                    {
+                        "source": "https://example.com/b",
+                        "created_at": stale.isoformat(),
+                    },
+                ),
+            ]
+
+        search("test")
+        records = memory_trail.query()
+
+        assert [r["freshness_status"] for r in records] == ["FRESH", "STALE"]
+
+    def test_track_single_document_provenance_unchanged(self, memory_trail):
+        # A non-sequence result still reads provenance from the result itself.
+        @memory_trail.track(source="retriever")
+        def search(query):
+            return self._Doc(
+                "only",
+                {
+                    "source": "https://example.com/solo",
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+
+        search("test")
+        records = memory_trail.query()
+
+        assert len(records) == 1
+        assert records[0]["provenance_status"] == "VALID"
+        prov = json.loads(records[0]["provenance_json"])
+        assert prov["source_url"] == "https://example.com/solo"
+
+    def test_track_reshaping_extractor_does_not_mispair_provenance(self, memory_trail):
+        # An extractor that collapses a batch into one item leaves no way to
+        # map content back to a document, so provenance falls back to the
+        # result as a whole rather than being paired with the wrong document.
+        @memory_trail.track(
+            source="retriever",
+            content_extractor=lambda docs: " ".join(d.page_content for d in docs),
+        )
+        def search(query):
+            return [
+                self._Doc("a", {"source": "https://example.com/a"}),
+                self._Doc("b", {"source": "https://example.com/b"}),
+            ]
+
+        search("test")
+        records = memory_trail.query()
+
+        assert len(records) == 1
+        assert records[0]["provenance_status"] == "MISSING"
+
     def test_track_async_function(self, memory_trail):
         @memory_trail.track(source="retriever", source_name="async_search")
         async def async_search(query):


### PR DESCRIPTION
## What does this PR do?

`_track_result` called `_extract_provenance` on the whole `result`. When a decorated function
returns a list of Documents, the list itself has no `.metadata`, so provenance came back `None`
for every document in the batch.

Reproduced on `main` with two documents carrying distinct sources and dates:

```
prov=MISSING   fresh=UNKNOWN  json=null
prov=MISSING   fresh=UNKNOWN  json=null
```

After this change:

```
prov=VALID  fresh=FRESH  {"source_url": "https://example.com/a", "created_at": "2026-08-01T..."}
prov=VALID  fresh=STALE  {"source_url": "https://example.com/b", "created_at": "2020-01-01T..."}
```

The second document is from 2020 and now correctly flags `STALE`. Previously it passed silently,
which is the compliance consequence the issue describes.

### Why not a plain `zip(result, items)`

The issue suggests zipping `result` with `items`. That is correct for the common case but
misbehaves with a custom `content_extractor`: if the extractor reshapes the batch, `zip` pairs
each content item with an unrelated document's provenance, attributing the wrong source to the
wrong content. `zip` also truncates silently when lengths differ.

So the pairing is guarded by an explicit rule in a new `_extract_provenances` helper:

- If `result` is a list or tuple **and** extraction produced exactly one item per element, read
  provenance from each element.
- Otherwise the mapping from item back to element is unknowable, so read provenance from
  `result` as a whole and share it, which is exactly the previous behaviour.

The helper always returns exactly one provenance per content item, so the loop uses
`zip(..., strict=True)`. Any future mismatch raises instead of silently dropping records.

This means every non-list path keeps its current behaviour: a single Document still reads its own
`.metadata`, a `str`/`dict`/`None` result behaves as before, and an extractor that collapses a
batch into one string falls back rather than guessing. All four cases have tests.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

Four new tests in `TestContextTrailTrack`: per-document provenance from a list, per-document
freshness (the `FRESH`/`STALE` split above), a single non-list Document still reading its own
metadata, and a reshaping extractor falling back without mispairing. The two list tests fail on
unfixed source; the other two are regression guards for the paths deliberately left unchanged,
so they pass either way. Full suite goes 514 to 518 passing, skips unchanged.

## Related Issues

Fixes #149
