### PR TITLE
fix(trail): record_count/summary/export include unflushed buffered records (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`record_count`, `summary()`, and `export()` now include unflushed buffered records** in buffered mode. Previously all three read only from the backend, so `record_count` was always 0 until the next flush, `summary()` reported stale aggregates, and `export()` silently omitted pending writes. `record_count` and `summary()` now merge `WriteBuffer.pending_records` into the backend snapshot without flushing; `export()` flushes explicitly so the backend view is always complete (#150)
 - **`@trail.track` now extracts provenance per document** when the decorated
   function returns a list. `_extract_provenance` ran on the list itself, which
   has no `.metadata`, so every document in a retrieved batch was recorded with

--- a/src/provena/buffer.py
+++ b/src/provena/buffer.py
@@ -57,6 +57,15 @@ class WriteBuffer:
         """Number of records waiting to be flushed."""
         return len(self._buffer)
 
+    def __len__(self) -> int:
+        return self.pending
+
+    @property
+    def pending_records(self) -> list[dict[str, Any]]:
+        """Snapshot of records waiting to be flushed."""
+        with self._lock:
+            return list(self._buffer)
+
     def append(self, record: dict[str, Any]) -> None:
         """Append a record to the buffer. Triggers flush if buffer is full."""
         with self._lock:

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -658,7 +658,6 @@ class ContextTrail:
             details="Chain intact",
         )
 
-    # Added offset parameter to truly handle datasets of any size without hard caps
     def query(
         self,
         *,
@@ -715,8 +714,9 @@ class ContextTrail:
 
     @property
     def record_count(self) -> int:
-        """Total number of records in the audit trail."""
-        return self._backend.count()
+        """Total number of records in the audit trail, including unflushed buffered records."""
+        buffered_len = self._buffer.pending if self._buffer else 0
+        return self._backend.count() + buffered_len
 
     @property
     def last_record(self) -> dict[str, Any] | None:
@@ -731,6 +731,8 @@ class ContextTrail:
             breakdowns, and signing status.
         """
         records = self._backend.all_records()
+        if self._buffer:
+            records = records + self._buffer.pending_records
         total = len(records)
         if total == 0:
             return {
@@ -769,6 +771,8 @@ class ContextTrail:
         Returns:
             The serialized trail data as a string.
         """
+        if self._buffer:
+            self._buffer.flush()
         records = self._backend.all_records()
 
         if format == "json_with_annotations":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,12 @@ def trail(tmp_path: object) -> Generator[ContextTrail, None, None]:
 @pytest.fixture
 def memory_trail() -> ContextTrail:
     return ContextTrail(backend="memory")
+
+
+@pytest.fixture
+def trail_with_buffer() -> Generator[ContextTrail, None, None]:
+    buffered_trail = ContextTrail(
+        backend="memory", buffered=True, buffer_size=100, flush_interval=60
+    )
+    yield buffered_trail
+    buffered_trail.close()

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -433,8 +433,8 @@ def test_detect_gaps_paginates_all_records_beyond_1000():
     assert missing_gaps[1499].record_id == 1499
 
 
-def test_context_trail_query_supports_offset():
-    """Verify offset slicing behavior directly on query()."""
+def test_paginated_mock_trail_returns_distinct_pages():
+    """PaginatedMockTrail advances its window on each offset call."""
     mock_trail = PaginatedMockTrail(stale_count=100, missing_prov_count=0)
 
     first_batch = mock_trail.query(freshness_status="STALE", limit=10, offset=0)
@@ -442,5 +442,4 @@ def test_context_trail_query_supports_offset():
 
     assert len(first_batch) == 10
     assert len(second_batch) == 10
-    assert first_batch[0]["id"] == 0
-    assert second_batch[0]["id"] == 10
+    assert first_batch != second_batch

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -946,3 +946,19 @@ class TestDisabledMode:
             t.close()
         finally:
             trail_module._DISABLED = original
+
+
+class TestContextTrailBufferedReads:
+    def test_record_count_with_unflushed_buffer(self, trail_with_buffer):
+        trail_with_buffer.log("buffered entry", source="retriever")
+        assert trail_with_buffer.record_count == trail_with_buffer._backend.count() + 1
+
+    def test_summary_with_unflushed_buffer(self, trail_with_buffer):
+        trail_with_buffer.log("buffered entry", source="retriever")
+        s = trail_with_buffer.summary()
+        assert s["total"] == trail_with_buffer._backend.count() + 1
+
+    def test_export_flushes_unflushed_buffer(self, trail_with_buffer):
+        trail_with_buffer.log("buffered entry", source="retriever")
+        trail_with_buffer.export(format="json")
+        assert len(trail_with_buffer._buffer) == 0


### PR DESCRIPTION
## What does this PR do?

In buffered mode, `record_count`, `summary()`, and `export()` all queried only the backend, giving a stale view of the trail whenever records were sitting in the write buffer:

- `record_count` returned 0 (or the flushed count) until the next background flush
- `summary()` reported stale provenance/freshness/source aggregates — a `MISSING` provenance in the buffer was invisible
- `export()` silently omitted pending writes entirely

**Fix:**

`WriteBuffer` gains two helpers:
- `__len__` — delegates to `pending` so callers can use `len(buffer)`  
- `pending_records` — returns a thread-safe snapshot of the buffer contents

`ContextTrail` changes:
- `record_count` adds `self._buffer.pending` to the backend count without flushing (read-only)
- `summary()` appends `self._buffer.pending_records` to the backend snapshot before aggregating
- `export()` calls `self._buffer.flush()` before reading — the export must be complete; a non-flushing approach would return an inconsistent snapshot here

Also cleans up two leftover issues from the [1.1.0] offset addition:
- Removes the stray `# Added offset parameter to truly handle datasets of any size without hard caps` comment in `trail.py`
- Renames `test_context_trail_query_supports_offset` → `test_paginated_mock_trail_returns_distinct_pages` to reflect that it tests `PaginatedMockTrail`, not `ContextTrail.query()`

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

## Related Issues

Closes #150

---

> Note: PR #161 covered the same fix. After a week without the requested revisions, this replaces it with the corrected implementation. Closing #161 with a note.