### PR TITLE
fix(retention): page through all expired records, remove 10k cap (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`RetentionEngine` no longer silently caps at 10,000 expired records per run** — `find_expired()` now pages through the full result set in batches, so `preview()` and `execute()` act on every expired record instead of only the first 10k (#102)
 - **`record_count`, `summary()`, and `export()` now include unflushed buffered records** in buffered mode. Previously all three read only from the backend, so `record_count` was always 0 until the next flush, `summary()` reported stale aggregates, and `export()` silently omitted pending writes. `record_count` and `summary()` now merge `WriteBuffer.pending_records` into the backend snapshot without flushing; `export()` flushes explicitly so the backend view is always complete (#150)
 - **`@trail.track` now extracts provenance per document** when the decorated
   function returns a list. `_extract_provenance` ran on the list itself, which

--- a/src/provena/retention.py
+++ b/src/provena/retention.py
@@ -40,6 +40,11 @@ class RetentionEngine:
     supports export-before-delete for compliance archival.
     """
 
+    #: Page size used when scanning for expired records. Exposed as an
+    #: attribute (rather than a hardcoded literal) so tests can shrink it to
+    #: exercise the multi-batch pagination path without inserting 10k+ rows.
+    _QUERY_BATCH_SIZE = 10000
+
     def __init__(
         self,
         trail: Any,
@@ -76,8 +81,18 @@ class RetentionEngine:
         """
         reference = now or datetime.now(timezone.utc)
         cutoff = reference - timedelta(days=self._retention_days)
-        result: list[dict[str, Any]] = self._trail.query(end=cutoff, limit=10000)
-        return result
+        batch = self._QUERY_BATCH_SIZE
+        expired: list[dict[str, Any]] = []
+        offset = 0
+        while True:
+            page: list[dict[str, Any]] = self._trail.query(
+                end=cutoff, limit=batch, offset=offset
+            )
+            expired.extend(page)
+            if len(page) < batch:
+                break
+            offset += batch
+        return expired
 
     def preview(self, now: datetime | None = None) -> dict[str, Any]:
         """Preview what a retention run would do without making changes.

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -140,3 +140,37 @@ class TestRetentionCLI:
         runner = CliRunner()
         result = runner.invoke(cli, ["retain", "--max-age", "30"])
         assert result.exit_code == 1
+
+
+class TestRetentionPagination:
+    """Regression tests for #102: retention must not silently cap at one batch."""
+
+    def _old_trail(self, count: int) -> ContextTrail:
+        trail = ContextTrail(backend="memory")
+        now = datetime.now(timezone.utc)
+        for i in range(count):
+            trail.log(f"old record {i}", source="retriever")
+        for record in trail._backend._records:
+            record["timestamp"] = (now - timedelta(days=400)).isoformat()
+        return trail
+
+    def test_find_expired_pages_beyond_one_batch(self):
+        trail = self._old_trail(7)
+        try:
+            engine = RetentionEngine(trail, retention_days=180)
+            engine._QUERY_BATCH_SIZE = 2
+            expired = engine.find_expired()
+            assert len(expired) == 7
+            assert engine.preview()["would_delete"] == 7
+        finally:
+            trail.close()
+
+    def test_execute_purges_all_beyond_one_batch(self):
+        trail = self._old_trail(7)
+        try:
+            engine = RetentionEngine(trail, retention_days=180)
+            engine._QUERY_BATCH_SIZE = 2
+            result = engine.execute()
+            assert result.deleted == 7
+        finally:
+            trail.close()


### PR DESCRIPTION
## What does this PR do?

`RetentionEngine.find_expired()` called `trail.query(end=cutoff, limit=10000)` — a single fixed-size query. Any trail with more than 10,000 expired records would silently drop the remainder: `preview()` under-counted, and `execute()` left those records undeleted while reporting success. For a compliance retention engine enforcing EU AI Act Art. 12 archival requirements, this is unacceptable.

**Fix:** Page through the full result set using `offset`:

```python
batch = self._QUERY_BATCH_SIZE
expired: list[dict[str, Any]] = []
offset = 0
while True:
    page = self._trail.query(end=cutoff, limit=batch, offset=offset)
    expired.extend(page)
    if len(page) < batch:
        break
    offset += batch
return expired
```

`_QUERY_BATCH_SIZE = 10000` is a class attribute instead of a hardcoded literal so tests can shrink it to 2 and exercise the multi-batch path without inserting 10k rows.

Two new regression tests verify that `find_expired()` and `execute()` correctly handle a trail whose expired record count exceeds one batch.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

## Related Issues

Closes #102

---

> Note: PR #158 covered the same fix but was blocked waiting on `offset` support in `ContextTrail.query()` (which was already shipped in v1.1.0). Applying it directly here with a clean rebase on current main.