### PR TITLE
fix(trail): reject non-positive record_id in annotate() (closes #143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`annotate()` rejects non-positive record IDs with a clear error.** In
+  buffered mode `log()` returns `TrailRecord(id=-1)` until the record is
+  flushed, and passing that placeholder to `annotate()` previously surfaced a
+  raw `sqlite3.IntegrityError` on SQLite, a foreign key violation on
+  PostgreSQL, and a differently worded `ValueError` in memory, none of which
+  mentioned buffering. All backends now raise the same `ValueError` naming the
+  cause and pointing at `flush()` (#143)
 - **`provena mcp serve` now closes the trail on exit** — the server call is wrapped in `try/finally`, so the SQLite handle/WAL is checkpointed and the final buffer flush runs even if `configure()`/`create_server()` raise or `server.run()` returns (#148)
 - **`verify_chain()` returns `ChainVerdict(intact=False)` for a `None`/malformed `chain_hash`** instead of raising `TypeError` out of `hmac.compare_digest`, so corrupted or hand-edited records are reported as broken links rather than crashing the audit path (#146)
 - **`InMemoryBackend.get()` and `get_last()` now hold the backend lock** when reading `_records`, matching every other method on the backend and closing a TOCTOU race that could raise `IndexError` under concurrent `append()` (#145)

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -318,6 +318,9 @@ class ContextTrail:
 
         Returns:
             The created TrailRecord, or None if a non-strict error occurred.
+            In buffered mode the record has not reached the backend yet, so
+            its ``id`` is the placeholder ``-1`` rather than a persisted row
+            id. Call ``flush()`` before using it with ``annotate()``.
         """
         try:
             return self._log_internal(
@@ -669,13 +672,26 @@ class ContextTrail:
         """Add a human oversight annotation to a trail record.
 
         Args:
-            record_id: The ID of the record to annotate.
+            record_id: The ID of the record to annotate. Must be >= 1.
             note: The annotation text.
             reviewer: Optional name of the reviewer.
 
         Returns:
             The ID of the created annotation.
+
+        Raises:
+            ValueError: If ``record_id`` is less than 1. In buffered mode
+                ``log()`` returns ``TrailRecord(id=-1)`` until the record
+                reaches the backend, and annotating that placeholder is
+                rejected by every backend with a different low-level error.
         """
+        if record_id < 1:
+            raise ValueError(
+                f"record_id must be >= 1, got {record_id}. In buffered mode "
+                "log() returns TrailRecord(id=-1) until the record is "
+                "flushed; call flush(), then read the persisted id from "
+                "last_record or query()."
+            )
         ts = datetime.now(timezone.utc).isoformat()
         return self._backend.add_annotation(record_id, note, reviewer, ts)
 

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -365,6 +365,71 @@ class TestContextTrailAnnotate:
         )
         assert ann_id >= 1
 
+    def test_buffered_log_returns_placeholder_id(self):
+        # Buffered records have not reached the backend yet, so log() cannot
+        # know the persisted row id. Pinning the sentinel keeps the annotate()
+        # guard below meaningful.
+        trail = ContextTrail(backend="memory", buffered=True)
+        try:
+            record = trail.log("pending", source="retriever")
+            assert record.id == -1
+        finally:
+            trail.close()
+
+    @pytest.mark.parametrize("bad_id", [-1, 0])
+    def test_annotate_rejects_non_positive_record_id(self, memory_trail, bad_id):
+        memory_trail.log("test", source="retriever")
+        with pytest.raises(ValueError, match="record_id must be >= 1"):
+            memory_trail.annotate(bad_id, "note", reviewer="alice")
+
+    def test_annotate_buffered_sentinel_error_mentions_flush(self):
+        # The old failure was backend-specific and never mentioned buffering:
+        # sqlite3.IntegrityError on SQLite, a different ValueError in memory.
+        # The message must point at the actual cause and the way out.
+        trail = ContextTrail(backend="memory", buffered=True)
+        try:
+            record = trail.log("pending", source="retriever")
+            with pytest.raises(ValueError) as exc:
+                trail.annotate(record.id, "Reviewed by human", reviewer="alice")
+            assert "buffered mode" in str(exc.value)
+            assert "flush()" in str(exc.value)
+        finally:
+            trail.close()
+
+    def test_annotate_sqlite_sentinel_raises_value_error(self):
+        # Previously sqlite3.IntegrityError ("FOREIGN KEY constraint failed")
+        # surfaced raw from the storage layer. All backends now agree.
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            trail = ContextTrail(storage_path=db_path, buffered=True)
+            record = trail.log("pending", source="retriever")
+            with pytest.raises(ValueError, match="record_id must be >= 1"):
+                trail.annotate(record.id, "note", reviewer="alice")
+            trail.close()
+        finally:
+            os.unlink(db_path)
+
+    def test_annotate_works_after_flush(self):
+        # The path the error message tells callers to take must actually work.
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+        try:
+            trail = ContextTrail(storage_path=db_path, buffered=True)
+            trail.log("needs review", source="retriever")
+            trail.flush()
+
+            record_id = trail.last_record["id"]
+            ann_id = trail.annotate(record_id, "Reviewed by human", reviewer="alice")
+
+            assert ann_id >= 1
+            annotations = trail.get_annotations(record_id)
+            assert len(annotations) == 1
+            assert annotations[0]["note"] == "Reviewed by human"
+            trail.close()
+        finally:
+            os.unlink(db_path)
+
 
 class TestContextTrailGetAnnotations:
     def test_empty_initially(self, memory_trail):


### PR DESCRIPTION
## What does this PR do?

`annotate()` now rejects `record_id < 1` with a `ValueError` that names buffered mode as the
cause and points at the way out:

```
record_id must be >= 1, got -1. In buffered mode log() returns TrailRecord(id=-1)
until the record is flushed; call flush(), then read the persisted id from
last_record or query().
```

`log()`'s docstring now documents the `-1` placeholder, which was previously undocumented.

### One correction to the issue

The issue says the annotation is *silently lost*. That is not what happens. I checked all three
backends and every one rejects it:

| Backend | Enforcement | Result with `record_id=-1` |
|---|---|---|
| SQLite | `FOREIGN KEY (record_id) REFERENCES trail(id)` with `PRAGMA foreign_keys=ON` | `sqlite3.IntegrityError: FOREIGN KEY constraint failed` |
| PostgreSQL | `record_id BIGINT NOT NULL REFERENCES trail(id)` | foreign key violation |
| InMemory | explicit existence check | `ValueError: Record -1 does not exist` |

So no annotation is lost, and the audit trail is not compromised. The real defect is that the
failure is **backend-specific and unactionable**: three different low-level errors, none of
which mention buffering. A user who sees `FOREIGN KEY constraint failed` has no way to connect
it to `buffered=True`.

That changes what the fix needs to be. The issue lists flushing synchronously or queueing
annotations until flush as options, but both are ways to prevent silent data loss that is not
actually occurring. Flushing on every `log()` would also remove the throughput that is buffered
mode's entire purpose. So this implements what the issue calls the minimum bar, which given the
corrected diagnosis is the appropriate fix rather than a partial one.

If you would still like the buffer to queue annotations and write them once records get real
IDs, that is a real ergonomic improvement and worth its own issue, but it means teaching
`WriteBuffer` to correlate queued records with backend-assigned IDs across a batched, threaded
flush. Happy to take it on separately.

### Verified

The path the error message recommends actually works:

```python
trail.flush()
record_id = trail.last_record["id"]
trail.annotate(record_id, "Reviewed by human", reviewer="alice")   # annotation 1
```

There is a test for it, so the advice in the message cannot silently rot.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes
- [x] `pytest` passes with no failures
- [x] CHANGELOG.md updated (if user-facing change)

Five new tests in `TestContextTrailAnnotate`: the buffered placeholder id, parametrized
rejection of `-1` and `0`, the error message naming buffering and `flush()`, SQLite raising
`ValueError` instead of `IntegrityError`, and the post-flush annotate path working end to end.
Four fail on unfixed source. The suite goes 514 to 520 passing, skips unchanged.

## Related Issues

Fixes #143
