### PR TITLE
docs(provenance): the summary line still promises trustworthy lineage

### DIFF
--- a/docs/guide/provenance.md
+++ b/docs/guide/provenance.md
@@ -2,8 +2,9 @@
 
 Provenance metadata records where a piece of context came from -- its origin
 URL, author, creation date, and version. Provena validates this metadata on
-every logged entry and assigns a verdict that tells you whether the context has
-a trustworthy lineage.
+every logged entry and assigns a verdict that tells you whether the declared
+lineage is **complete**. Completeness is not the same as truthfulness: see
+[VALID means present, not verified](#validation-verdicts) below.
 
 ## ProvenanceMetadata
 
@@ -86,6 +87,11 @@ print(summary["provenance"])
     the record, but a `BLOCK`-level `DENY` fires after the record is
     persisted and the chain has advanced, so the declaration still ends up
     in the trail.
+
+    There is no fourth verdict for *present but uncorroborated*, because from
+    the validator's position every `VALID` entry is uncorroborated. Read a
+    `VALID` count as "the callers declared an origin this often", never as
+    "the origins were confirmed this often".
 
 ## Default Required Fields
 


### PR DESCRIPTION
Rewritten and cut down after checking what is already merged. The first version of this PR restated a note I had landed myself in #139, which was a waste of your time to read; sorry about that.

What is left is one contradiction that #139 did not touch. The note under Validation Verdicts says a VALID verdict means present, not verified. The opening paragraph, seventy lines above it, still tells the reader the verdict says "whether the context has a trustworthy lineage". A reader who stops at the summary gets the opposite of what the note says, and the summary is the part that gets quoted.

So the change is the summary line, plus a link down to the note, plus one sentence inside the note about why there is no fourth verdict.

Eight lines added, two removed. Everything else from the earlier version is dropped because #139 already covers it.

Verified before writing, not assumed: the validator imports no network client and never fetches `source_url`, and nothing compares `created_at` against the log time. Happy to drop the "no fourth verdict" sentence if you would rather the note stayed as short as it is.
