### PR TITLE
fix(trail): verify buffered records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`verify_chain()` now flushes pending buffered records before verification** so its verdict always covers the complete trail instead of silently checking only the persisted prefix (#142)
 - **`RetentionEngine` no longer silently caps at 10,000 expired records per run** — `find_expired()` now pages through the full result set in batches, so `preview()` and `execute()` act on every expired record instead of only the first 10k (#102)
 - **`record_count`, `summary()`, and `export()` now include unflushed buffered records** in buffered mode. Previously all three read only from the backend, so `record_count` was always 0 until the next flush, `summary()` reported stale aggregates, and `export()` silently omitted pending writes. `record_count` and `summary()` now merge `WriteBuffer.pending_records` into the backend snapshot without flushing; `export()` flushes explicitly so the backend view is always complete (#150)
 - **`@trail.track` now extracts provenance per document** when the decorated

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -617,12 +617,17 @@ class ContextTrail:
     def verify_chain(self) -> ChainVerdict:
         """Verify the integrity of the entire hash chain.
 
+        Flushes pending buffered records before verification so the verdict
+        always covers the complete trail.
+
         Recomputes every chain hash from the genesis hash forward and checks
         each against the stored value.
 
         Returns:
             A ChainVerdict indicating whether the chain is intact.
         """
+        if self._buffer is not None:
+            self._buffer.flush()
         records = self._backend.all_records()
         if not records:
             return ChainVerdict(intact=True, total_records=0, details="Empty trail")

--- a/tests/test_trail.py
+++ b/tests/test_trail.py
@@ -962,3 +962,16 @@ class TestContextTrailBufferedReads:
         trail_with_buffer.log("buffered entry", source="retriever")
         trail_with_buffer.export(format="json")
         assert len(trail_with_buffer._buffer) == 0
+
+    def test_verify_chain_flushes_and_checks_pending_records(self, trail_with_buffer):
+        trail_with_buffer.log("persisted entry", source="retriever")
+        trail_with_buffer.flush()
+        trail_with_buffer.log("tampered pending entry", source="retriever")
+        trail_with_buffer._buffer._buffer[0]["chain_hash"] = "tampered"
+
+        verdict = trail_with_buffer.verify_chain()
+
+        assert not verdict.intact
+        assert verdict.total_records == 2
+        assert verdict.broken_at == 2
+        assert trail_with_buffer._buffer.pending == 0


### PR DESCRIPTION
Closes #142.

`verify_chain()` now flushes the write buffer before reading the backend, so its verdict covers pending records as well as the persisted prefix. The regression mixes persisted and buffered records, corrupts the pending link, and confirms verification detects it after flushing.

Validation:
- 522 passed, 24 skipped
- Ruff check/format passed
- `mypy src/provena/trail.py` passed

Full-project mypy currently reports an unrelated existing `opentelemetry.trace.get_tracer` typing error after resolving the latest optional OTel packages.
