### PR TITLE
Flush all active buffers on SIGTERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`SIGTERM` flushes every active `WriteBuffer`** through one process-wide
+  handler instead of replacing the previous buffer's handler whenever another
+  buffered trail is created (#112)
 - **`RetentionEngine` no longer silently caps at 10,000 expired records per run** — `find_expired()` now pages through the full result set in batches, so `preview()` and `execute()` act on every expired record instead of only the first 10k (#102)
 - **`record_count`, `summary()`, and `export()` now include unflushed buffered records** in buffered mode. Previously all three read only from the backend, so `record_count` was always 0 until the next flush, `summary()` reported stale aggregates, and `export()` silently omitted pending writes. `record_count` and `summary()` now merge `WriteBuffer.pending_records` into the backend snapshot without flushing; `export()` flushes explicitly so the backend view is always complete (#150)
 - **`@trail.track` now extracts provenance per document** when the decorated

--- a/src/provena/buffer.py
+++ b/src/provena/buffer.py
@@ -12,6 +12,8 @@ from collections import deque
 from typing import Any, Protocol
 
 _logger = logging.getLogger("provena.buffer")
+_active_buffers: weakref.WeakSet[WriteBuffer] = weakref.WeakSet()
+_active_buffers_lock = threading.RLock()
 
 
 class _Appendable(Protocol):
@@ -48,9 +50,7 @@ class WriteBuffer:
         self._finalizer = weakref.finalize(
             self, _weak_flush, self._buffer, self._lock, self._backend
         )
-
-        with contextlib.suppress(OSError, ValueError):
-            signal.signal(signal.SIGTERM, self._sigterm_handler)
+        _register_for_sigterm(self)
 
     @property
     def pending(self) -> int:
@@ -85,6 +85,7 @@ class WriteBuffer:
             self._thread.join(timeout=5)
         with self._lock:
             self._flush_locked()
+        _unregister_for_sigterm(self)
 
     def _flush_loop(self) -> None:
         while not self._stop.is_set():
@@ -115,10 +116,30 @@ class WriteBuffer:
         with self._lock:
             self._flush_locked()
 
-    def _sigterm_handler(self, signum: int, frame: Any) -> None:
+    def _sigterm_flush(self) -> None:
         self._stop.set()
         with self._lock:
             self._flush_locked()
+
+
+def _register_for_sigterm(buffer: WriteBuffer) -> None:
+    with _active_buffers_lock:
+        _active_buffers.add(buffer)
+        with contextlib.suppress(OSError, ValueError):
+            if signal.getsignal(signal.SIGTERM) is not _sigterm_handler:
+                signal.signal(signal.SIGTERM, _sigterm_handler)
+
+
+def _unregister_for_sigterm(buffer: WriteBuffer) -> None:
+    with _active_buffers_lock:
+        _active_buffers.discard(buffer)
+
+
+def _sigterm_handler(signum: int, frame: Any) -> None:
+    with _active_buffers_lock:
+        buffers = tuple(_active_buffers)
+    for buffer in buffers:
+        buffer._sigterm_flush()
 
 
 def _weak_flush(

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import signal
 import time
 
 from provena import ContextTrail
@@ -90,6 +91,26 @@ class TestWriteBuffer:
         buf = WriteBuffer(backend, buffer_size=100, flush_interval=60)
         assert buf.flush() == 0
         buf.close()
+
+    def test_sigterm_flushes_every_active_buffer(self):
+        previous_handler = signal.getsignal(signal.SIGTERM)
+        first_backend = InMemoryBackend()
+        second_backend = InMemoryBackend()
+        first = WriteBuffer(first_backend, buffer_size=100, flush_interval=60)
+        handler = signal.getsignal(signal.SIGTERM)
+        second = WriteBuffer(second_backend, buffer_size=100, flush_interval=60)
+        try:
+            first.append({"content_hash": "first"})
+            second.append({"content_hash": "second"})
+            assert signal.getsignal(signal.SIGTERM) is handler
+            assert callable(handler)
+            handler(signal.SIGTERM, None)
+            assert first_backend.count() == 1
+            assert second_backend.count() == 1
+        finally:
+            first.close()
+            second.close()
+            signal.signal(signal.SIGTERM, previous_handler)
 
 
 class TestContextTrailBuffered:


### PR DESCRIPTION
Fixes #112.

Use one process-wide SIGTERM handler that flushes every active `WriteBuffer`, with regression coverage for simultaneous buffers.

Validation: 513 tests passed; Ruff, formatting, and targeted strict MyPy passed.
