### PR TITLE
Unify CLI compliance report content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **CLI compliance reports now contain the same audit evidence in JSON, text,
+  and PDF formats** by routing every compliance format through the shared report
+  generator. JSON and text no longer omit the compliance score, issue list, or
+  EU AI Act article checks (#93)
 - **`RetentionEngine` no longer silently caps at 10,000 expired records per run** — `find_expired()` now pages through the full result set in batches, so `preview()` and `execute()` act on every expired record instead of only the first 10k (#102)
 - **`record_count`, `summary()`, and `export()` now include unflushed buffered records** in buffered mode. Previously all three read only from the backend, so `record_count` was always 0 until the next flush, `summary()` reported stale aggregates, and `export()` silently omitted pending writes. `record_count` and `summary()` now merge `WriteBuffer.pending_records` into the backend snapshot without flushing; `export()` flushes explicitly so the backend view is always complete (#150)
 - **`@trail.track` now extracts provenance per document** when the decorated

--- a/src/provena/cli/main.py
+++ b/src/provena/cli/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import click
@@ -197,50 +197,31 @@ def verify(ctx: click.Context) -> None:
 @click.pass_context
 def report(ctx: click.Context, fmt: str, output: str | None) -> None:
     """Generate a context governance compliance report."""
-    trail, db_path = _open_trail(ctx)
+    trail, _ = _open_trail(ctx)
     try:
-        summary = trail.summary()
-        verdict = trail.verify_chain()
+        if fmt == "csv":
+            csv_content = trail.export(format="csv")
+            if output:
+                with open(output, "w") as f:
+                    f.write(csv_content)
+                click.echo(f"Report written to {output}")
+            else:
+                click.echo(csv_content)
+            return
 
-        report_data = {
-            "generated_at": datetime.now(timezone.utc).isoformat(),
-            "database": db_path,
-            "total_records": summary["total"],
-            "chain_integrity": {
-                "status": "INTACT" if verdict.intact else "BROKEN",
-                "records_verified": verdict.total_records,
-                "broken_at": verdict.broken_at,
-            },
-            "provenance": summary.get("provenance", {}),
-            "freshness": summary.get("freshness", {}),
-            "sources": summary.get("sources", {}),
-            "signed": summary.get("signed", False),
-        }
+        from provena.report import generate_report
 
+        content = generate_report(trail, format=fmt)
         if fmt == "pdf":
-            from provena.report import generate_pdf_report
-
             pdf_path = output or "provena-report.pdf"
-            generate_pdf_report(trail, pdf_path)
+            if not isinstance(content, bytes):  # pragma: no cover - format contract
+                raise TypeError("PDF report renderer returned non-bytes content")
+            with open(pdf_path, "wb") as f:
+                f.write(content)
             click.echo(f"PDF report written to {pdf_path}")
-        elif fmt == "json":
-            content = json.dumps(report_data, indent=2)
-            if output:
-                with open(output, "w") as f:
-                    f.write(content)
-                click.echo(f"Report written to {output}")
-            else:
-                click.echo(content)
-        elif fmt == "csv":
-            content = trail.export(format="csv")
-            if output:
-                with open(output, "w") as f:
-                    f.write(content)
-                click.echo(f"Report written to {output}")
-            else:
-                click.echo(content)
         else:
-            content = _format_text_report(report_data)
+            if not isinstance(content, str):  # pragma: no cover - format contract
+                raise TypeError(f"{fmt} report renderer returned non-text content")
             if output:
                 with open(output, "w") as f:
                     f.write(content)
@@ -606,43 +587,6 @@ def _print_plain_table(records: list[dict[str, Any]]) -> None:
             f"{r.get('provenance_status', '?'):12s}  "
             f"{r.get('freshness_status', '?'):7s}"
         )
-
-
-def _format_text_report(data: dict[str, Any]) -> str:
-    lines = [
-        "=" * 50,
-        "PROVENA GOVERNANCE REPORT",
-        "=" * 50,
-        f"Generated: {data['generated_at']}",
-        f"Database:  {data['database']}",
-        f"Records:   {data['total_records']}",
-        f"Signed:    {'Yes' if data.get('signed') else 'No'}",
-        "",
-        "Chain Integrity:",
-        f"  Status:   {data['chain_integrity']['status']}",
-        f"  Verified: {data['chain_integrity']['records_verified']} records",
-    ]
-
-    if data["chain_integrity"]["broken_at"] is not None:
-        lines.append(f"  Broken at record: {data['chain_integrity']['broken_at']}")
-
-    lines.append("")
-    lines.append("Provenance:")
-    for status, count in sorted(data.get("provenance", {}).items()):
-        lines.append(f"  {status:12s} {count}")
-
-    lines.append("")
-    lines.append("Freshness:")
-    for status, count in sorted(data.get("freshness", {}).items()):
-        lines.append(f"  {status:12s} {count}")
-
-    lines.append("")
-    lines.append("Sources:")
-    for src, count in sorted(data.get("sources", {}).items()):
-        lines.append(f"  {src:12s} {count}")
-
-    lines.append("=" * 50)
-    return "\n".join(lines)
 
 
 @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -425,11 +425,13 @@ class TestCLIReport:
             result = runner.invoke(cli, ["--db", db_path, "report"])
             assert result.exit_code == 0
             data = json.loads(result.output)
-            assert data["total_records"] == 3
+            assert data["summary"]["total_records"] == 3
             assert data["chain_integrity"]["status"] == "INTACT"
-            assert "provenance" in data
-            assert "freshness" in data
-            assert "sources" in data
+            assert "compliance_score" in data
+            assert "eu_ai_act" in data
+            assert "provenance" in data["summary"]
+            assert "freshness" in data["summary"]
+            assert "sources" in data["summary"]
         finally:
             os.unlink(db_path)
 
@@ -439,8 +441,10 @@ class TestCLIReport:
             runner = CliRunner()
             result = runner.invoke(cli, ["--db", db_path, "report", "--format", "text"])
             assert result.exit_code == 0
-            assert "PROVENA GOVERNANCE REPORT" in result.output
-            assert "Chain Integrity" in result.output
+            assert "Provena Governance Compliance Report" in result.output
+            assert "COMPLIANCE SCORE" in result.output
+            assert "CHAIN INTEGRITY" in result.output
+            assert "EU AI ACT" in result.output
             assert "INTACT" in result.output
         finally:
             os.unlink(db_path)
@@ -460,7 +464,9 @@ class TestCLIReport:
 
             with open(out_path) as f:
                 data = json.loads(f.read())
-            assert data["total_records"] == 3
+            assert data["summary"]["total_records"] == 3
+            assert "compliance_score" in data
+            assert "eu_ai_act" in data
         finally:
             os.unlink(db_path)
             os.unlink(out_path)
@@ -492,6 +498,34 @@ class TestCLIReport:
 
             assert "id,timestamp,source,source_name,content_hash" in content
             assert "src_0" in content
+        finally:
+            os.unlink(db_path)
+            os.unlink(out_path)
+
+    def test_report_pdf_to_file_uses_shared_generator(self, monkeypatch):
+        from provena import report as report_module
+
+        db_path = _create_trail_db()
+        with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as f:
+            out_path = f.name
+
+        formats = []
+
+        def fake_generate_report(trail, *, format):
+            formats.append(format)
+            return b"%PDF-shared-report"
+
+        monkeypatch.setattr(report_module, "generate_report", fake_generate_report)
+        try:
+            result = CliRunner().invoke(
+                cli,
+                ["--db", db_path, "report", "--format", "pdf", "--output", out_path],
+            )
+
+            assert result.exit_code == 0
+            assert formats == ["pdf"]
+            with open(out_path, "rb") as f:
+                assert f.read() == b"%PDF-shared-report"
         finally:
             os.unlink(db_path)
             os.unlink(out_path)

--- a/tests/test_integration_e2e.py
+++ b/tests/test_integration_e2e.py
@@ -528,11 +528,13 @@ class TestMultiSourceAgentPipeline:
             assert result.exit_code == 0
 
             report = json.loads(result.output)
-            assert report["total_records"] == api_summary["total"]
+            assert report["summary"]["total_records"] == api_summary["total"]
             assert report["chain_integrity"]["status"] == "INTACT"
-            assert report["provenance"] == api_summary["provenance"]
-            assert report["freshness"] == api_summary["freshness"]
-            assert report["sources"] == api_summary["sources"]
+            assert report["summary"]["provenance"] == api_summary["provenance"]
+            assert report["summary"]["freshness"] == api_summary["freshness"]
+            assert report["summary"]["sources"] == api_summary["sources"]
+            assert "compliance_score" in report
+            assert "eu_ai_act" in report
         finally:
             os.unlink(db_path)
 


### PR DESCRIPTION
Fixes #93.

Route JSON, text, and PDF CLI reports through the shared compliance generator, while preserving CSV export behavior.

Validation: 512 tests passed; focused CLI and integration tests, Ruff, formatting, and strict MyPy passed.
