### PR TITLE
fix: close() leaks backend when buffer flush raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`ContextTrail.close()` now closes the backend even if flushing the buffer fails** — the two calls are wrapped in `try/finally`, so a disk-full or I/O error during the final buffer flush no longer leaks the SQLite connection or skips the WAL checkpoint (#144)
 - **`provena mcp serve` now closes the trail on exit** — the server call is wrapped in `try/finally`, so the SQLite handle/WAL is checkpointed and the final buffer flush runs even if `configure()`/`create_server()` raise or `server.run()` returns (#148)
 - **`verify_chain()` returns `ChainVerdict(intact=False)` for a `None`/malformed `chain_hash`** instead of raising `TypeError` out of `hmac.compare_digest`, so corrupted or hand-edited records are reported as broken links rather than crashing the audit path (#146)
 - **`InMemoryBackend.get()` and `get_last()` now hold the backend lock** when reading `_records`, matching every other method on the backend and closing a TOCTOU race that could raise `IndexError` under concurrent `append()` (#145)

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -825,9 +825,11 @@ class ContextTrail:
 
     def close(self) -> None:
         """Close the storage backend and release resources."""
-        if self._buffer is not None:
-            self._buffer.close()
-        self._backend.close()
+        try:
+            if self._buffer is not None:
+                self._buffer.close()
+        finally:
+            self._backend.close()
 
     def _handle_error(self, exc: Exception) -> None:
         with self._lock:

--- a/tests/test_buffer.py
+++ b/tests/test_buffer.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import time
 
+import pytest
+
 from provena import ContextTrail
 from provena.buffer import WriteBuffer
 from provena.storage import InMemoryBackend
@@ -115,6 +117,23 @@ class TestContextTrailBuffered:
         trail.close()
         # After close, records should have been flushed
         # Can't query after close, but buffer should be empty
+
+    def test_close_closes_backend_even_if_buffer_close_raises(self, tmp_path):
+        db_path = str(tmp_path / "trail.db")
+        trail = ContextTrail(
+            storage_path=db_path, buffered=True, buffer_size=100, flush_interval=60
+        )
+        trail.log("data", source="retriever")
+        real_close = trail._buffer.close
+
+        def boom() -> None:
+            real_close()
+            raise OSError("simulated disk full")
+
+        trail._buffer.close = boom  # type: ignore[method-assign]
+        with pytest.raises(OSError, match="simulated disk full"):
+            trail.close()
+        assert trail._backend._conn is None
 
     def test_buffered_chain_integrity(self):
         trail = ContextTrail(


### PR DESCRIPTION
## What does this PR do?

`ContextTrail.close()` called `self._buffer.close()` then `self._backend.close()`
sequentially with no `try/finally`. If the buffer's flush raised (e.g. disk-full,
I/O error), the backend connection was never closed — leaking the SQLite file
handle and skipping the WAL checkpoint.

Wraps the buffer close in `try/finally` so the backend always closes, matching
the `try/finally: trail.close()` pattern used elsewhere in the codebase (and the
same shutdown-reliability fix already applied to `provena mcp serve` in #148).

Added `test_close_closes_backend_even_if_buffer_close_raises` in
`tests/test_buffer.py`: monkeypatches `_buffer.close` to call through to the
real close (so the buffer's own cleanup runs normally) and then raise,
asserting `_backend._conn` is `None` afterward.

**Related finding, not in scope for this PR:** while fixing this, noticed the
same unprotected-shutdown-chain pattern in `TrailAggregator.close()`
(`src/provena/aggregator.py:438-441`) — if one registered trail's `.close()`
raises, the loop stops and every trail after it never gets closed. Unlike this
issue, there's no existing docstring/test/docs specifying intended behavior
there (best-effort vs. fail-fast), so I didn't fold a fix in here. Happy to
open a follow-up once there's guidance on which semantics are wanted.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes (1 pre-existing unrelated error on `main`, untouched by this change)
- [x] `pytest` passes with no failures (504 passed, 33 skipped — unrelated optional integrations)
- [x] CHANGELOG.md updated

## Related Issues

Fixes #144