### PR TITLE
test(cli): add TestCLIRetain covering dry-run, execute, EU minimum, a…

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from click.testing import CliRunner
@@ -584,6 +584,89 @@ class TestCLIExport:
         runner = CliRunner()
         result = runner.invoke(cli, ["--db", "/nonexistent/path.db", "export"])
         assert result.exit_code != 0
+
+
+class TestCLIRetain:
+    def _age_record(self, db_path: str, record_id: int, days: int) -> None:
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "UPDATE trail SET timestamp = ? WHERE id = ?",
+            ((datetime.now(timezone.utc) - timedelta(days=days)).isoformat(), record_id),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_retain_dry_run(self):
+        db_path = _create_trail_db(1)
+        self._age_record(db_path, 1, days=400)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["--db", db_path, "retain", "--max-age", "180", "--dry-run"]
+            )
+            assert result.exit_code == 0
+            assert "would be deleted" in result.output
+
+            conn = sqlite3.connect(db_path)
+            count = conn.execute("SELECT COUNT(*) FROM trail").fetchone()[0]
+            conn.close()
+            assert count == 1
+        finally:
+            os.unlink(db_path)
+
+    def test_retain_execute(self):
+        db_path = _create_trail_db(1)
+        self._age_record(db_path, 1, days=400)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--db", db_path, "retain", "--max-age", "180"])
+            assert result.exit_code == 0
+            assert "DONE" in result.output
+            assert "Deleted 1 records" in result.output
+        finally:
+            os.unlink(db_path)
+
+    def test_retain_below_eu_minimum(self):
+        db_path = _create_trail_db(1)
+        try:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--db", db_path, "retain", "--max-age", "90"])
+            assert result.exit_code == 1
+            assert "EU AI Act" in result.output
+        finally:
+            os.unlink(db_path)
+
+    def test_retain_archive(self, tmp_path):
+        db_path = _create_trail_db(1)
+        self._age_record(db_path, 1, days=400)
+        archive_path = tmp_path / "archive.json"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--db",
+                    db_path,
+                    "retain",
+                    "--archive",
+                    str(archive_path),
+                    "--max-age",
+                    "365",
+                ],
+            )
+            assert result.exit_code == 0
+            assert "Archived 1 records" in result.output
+
+            data = json.loads(archive_path.read_text())
+            assert data["record_count"] == 1
+        finally:
+            os.unlink(db_path)
+
+    def test_retain_missing_db(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--db", "/nonexistent/path.db", "retain"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
 
 
 class TestCLISummary:


### PR DESCRIPTION
## What does this PR do?

Adds `TestCLIRetain` to `tests/test_cli.py`, closing the CLI-level test gap
for the `retain` command (#83). The `RetentionEngine` itself already had
coverage, but the command's arg parsing, output formatting, and error
handling were untested.

Five tests, following the existing `TestCLIAudit`/`TestCLIVerify` pattern
(`CliRunner`, temp sqlite db, pre-populated records):
- `test_retain_dry_run` — `--dry-run` previews deletions without applying them
- `test_retain_execute` — real deletion path removes the expired record
- `test_retain_below_eu_minimum` — `--max-age` under the EU AI Act's 180-day
  floor is rejected (exit 1)
- `test_retain_archive` — `--archive` exports records to JSON before deletion
- `test_retain_missing_db` — nonexistent `--db` path fails cleanly

Added a small `_age_record()` helper (direct sqlite `timestamp` rewrite) so
tests can simulate aged records without waiting on real time.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [ ] `mypy src/provena/` passes — pre-existing unrelated failure on `main`:
      `src/provena/mcp_server.py:13: error: Unused "type: ignore" comment`.
      Confirmed present before this change too; not touched by this PR.
- [x] `pytest` passes with no failures (521 passed, 33 skipped — Postgres
      tests skipped, no local Postgres instance)
- [ ] CHANGELOG.md updated (if user-facing change) — not applicable, test-only change

## Related Issues

Fixes #83