### PR TITLE
fix: require_signing() always DENYs when invoked from from_config()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **`PolicyEngine.from_config()` now accepts a `_signed_ref` to wire `require_signing` to the trail's real signing state.** Previously, calling `from_config()` standalone (without a `ContextTrail` to patch it afterward) built a `require_signing` policy stuck on its `[False]` default, so a `block`-level `require_signing` check would deny every record regardless of whether the trail was signed. `ContextTrail(config=...)` now passes its own signing state through directly instead of relying solely on the post-construction patch (#141)
+
 ## [1.2.0] - 2026-09-07
 
 ### Added

--- a/src/provena/policy.py
+++ b/src/provena/policy.py
@@ -153,7 +153,12 @@ class PolicyEngine:
         return PolicyEvaluation(decision=decision, results=tuple(results))
 
     @classmethod
-    def from_config(cls, config: list[dict[str, Any]]) -> PolicyEngine:
+    def from_config(
+        cls,
+        config: list[dict[str, Any]],
+        *,
+        _signed_ref: list[bool] | None = None,
+    ) -> PolicyEngine:
         """Build a PolicyEngine from a list of declarative policy dicts.
 
         Each dict should have keys: ``check``, ``enforcement`` (optional,
@@ -161,6 +166,14 @@ class PolicyEngine:
 
         Supported checks: ``"freshness"``, ``"provenance"``,
         ``"require_signing"``, ``"source_allowlist"``.
+
+        Args:
+            config: The declarative policy list.
+            _signed_ref: Mutable reference to the trail's signing state,
+                wired through to ``require_signing()``. Callers that build
+                a ``PolicyEngine`` standalone (without a ``ContextTrail``)
+                must supply this themselves, or ``require_signing`` will
+                treat the trail as unsigned.
         """
         policies: list[Policy] = []
         for entry in config:
@@ -186,7 +199,9 @@ class PolicyEngine:
                     provenance_check(status=status, enforcement=enforcement)
                 )
             elif check_name == "require_signing":
-                policies.append(require_signing(enforcement=enforcement))
+                policies.append(
+                    require_signing(enforcement=enforcement, _signed_ref=_signed_ref)
+                )
             elif check_name == "source_allowlist":
                 allowed = entry.get("sources", [])
                 policies.append(

--- a/src/provena/trail.py
+++ b/src/provena/trail.py
@@ -189,7 +189,11 @@ class ContextTrail:
         key = _resolve_signing_key(key_value)
         self._hasher = ChainHasher(signing_key=key)
         self._policy_engine = (
-            PolicyEngine.from_config(policy_config) if policy_config else PolicyEngine()
+            PolicyEngine.from_config(
+                policy_config, _signed_ref=[self._hasher.is_signed]
+            )
+            if policy_config
+            else PolicyEngine()
         )
         self._update_signing_policies()
         self._validator = ProvenanceValidator(

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from provena import ContextTrail
+from provena.policy import PolicyViolation
 
 
 class TestTOMLConfig:
@@ -38,6 +39,35 @@ class TestTOMLConfig:
         trail = ContextTrail(config=str(config_file))
         record = trail.log("test", source="retriever")
         assert record is not None
+        trail.close()
+
+    def test_toml_require_signing_passes_on_signed_trail(self, tmp_path):
+        config_file = tmp_path / "provena.toml"
+        config_file.write_text(
+            '[storage]\nbackend = "memory"\n\n'
+            '[hash_chain]\nsigning_key = "test-secret"\n\n'
+            "[[policies]]\n"
+            'check = "require_signing"\n'
+            'enforcement = "block"\n'
+        )
+        trail = ContextTrail(config=str(config_file))
+        assert trail.is_signed
+        record = trail.log("test", source="retriever")
+        assert record is not None
+        trail.close()
+
+    def test_toml_require_signing_blocks_unsigned_trail(self, tmp_path):
+        config_file = tmp_path / "provena.toml"
+        config_file.write_text(
+            '[storage]\nbackend = "memory"\n\n'
+            "[[policies]]\n"
+            'check = "require_signing"\n'
+            'enforcement = "block"\n'
+        )
+        trail = ContextTrail(config=str(config_file))
+        assert not trail.is_signed
+        with pytest.raises(PolicyViolation):
+            trail.log("test", source="retriever")
         trail.close()
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -209,6 +209,21 @@ class TestPolicyEngineFromConfig:
         assert len(engine.policies) == 1
         assert engine.policies[0].name == "require_signing"
 
+    def test_require_signing_config_defaults_to_unsigned(self):
+        config = [{"check": "require_signing", "enforcement": "block"}]
+        engine = PolicyEngine.from_config(config)
+        assert engine.policies[0].check(None) is False
+
+    def test_require_signing_config_with_signed_ref(self):
+        config = [{"check": "require_signing", "enforcement": "block"}]
+        engine = PolicyEngine.from_config(config, _signed_ref=[True])
+        assert engine.policies[0].check(None) is True
+
+    def test_require_signing_config_with_unsigned_ref(self):
+        config = [{"check": "require_signing", "enforcement": "block"}]
+        engine = PolicyEngine.from_config(config, _signed_ref=[False])
+        assert engine.policies[0].check(None) is False
+
     def test_source_allowlist_config(self):
         config = [
             {


### PR DESCRIPTION
## What does this PR do?

`PolicyEngine.from_config()` called `require_signing(enforcement=...)` without passing `_signed_ref`, so the check's mutable reference permanently defaulted to `[False]`. A `block`-level `require_signing` policy configured via TOML/YAML denied every record, regardless of the trail's actual signing state.

Worth noting while investigating: `ContextTrail(config=...)` already worked correctly in practice, because `_update_signing_policies()` (`trail.py`) walks the policy list right after construction and rebuilds any `require_signing` policy with the real signing state — patching over the bug. The part that stayed genuinely broken is `PolicyEngine.from_config()` used **standalone**, without a `ContextTrail` to apply that patch afterward (it's a public
classmethod, exercised directly in `tests/test_policy.py`).

Sticking to **option 1** from the issue (thread a live `_signed_ref` through `from_config()`), rather than option 2 (inspect the record directly), because the `_signed_ref: list[bool] | None` mutable-reference pattern is already the
mechanism `require_signing()` itself defines and `_update_signing_policies()`already relies on (`trail.py`) — this just makes `from_config()` capable of using that same existing mechanism directly, instead of only being reachable
through the after-the-fact patch. Option 2 would need a new `signed_hash`-style field that doesn't exist anywhere in `TrailRecord`, the storage dict built in `trail.py`, or the SQLite/Postgres schema — grepping the codebase shows "signed" is exclusively a trail-level property everywhere it's used (`summary()`, `health()`, CLI, reports, `TrailAggregator.all_signed`), since one `ContextTrail` uses one `ChainHasher` for its entire lifetime and no record
can be signed differently from any other record in the same trail.

`from_config()` now accepts an optional `_signed_ref` and threads it to `require_signing()`. `ContextTrail._apply_config()` passes the trail's real signing state directly at construction time, so it no longer relies solely on the post-construction patch. `_update_signing_policies()` is left in place, it's still required for the `policies=[require_signing(...)]` direct- construction path in `__init__`, and is now a harmless no-op for the config path.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes (1 pre-existing unrelated error on `main`, untouched by this change)
- [x] `pytest` passes with no failures (537 passed, 33 skipped — unrelated optional integrations)
- [x] CHANGELOG.md updated

## Related Issues

Fixes #141