### PR TITLE
fix: TrailAggregator.close() leaks trails after one raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **`TrailAggregator.close()` now closes every registered trail even if one raises**, matching the `try/finally` protection `ContextTrail.close()` already has (#144). Previously, one trail's `close()` raising would stop the loop early and leak the backends of every trail registered after it. The first exception is now raised after all trails have had a chance to close; any additional exceptions are logged instead of being silently dropped (#177)
+
 ## [1.2.0] - 2026-09-07
 
 ### Added

--- a/src/provena/aggregator.py
+++ b/src/provena/aggregator.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from provena.models import ChainVerdict, ContextSource
+
+_logger = logging.getLogger("provena.aggregator")
 
 
 @dataclass(frozen=True, slots=True)
@@ -436,9 +439,28 @@ class TrailAggregator:
         return tuple(h for h in self._handoffs if h.run_id == run_id)
 
     def close(self) -> None:
-        """Close all registered trails."""
+        """Close all registered trails.
+
+        Closing continues even if a trail raises, so one failing trail
+        cannot leak the backends of the trails registered after it. If any
+        trail failed to close, the first exception is raised after every
+        trail has had a chance to close; any additional exceptions are
+        logged rather than dropped silently.
+        """
+        errors: list[Exception] = []
         for trail in self._trails.values():
-            trail.close()
+            try:
+                trail.close()
+            except Exception as exc:
+                errors.append(exc)
+
+        if errors:
+            for extra_error in errors[1:]:
+                _logger.warning(
+                    "Trail close() raised during aggregator shutdown",
+                    exc_info=extra_error,
+                )
+            raise errors[0]
 
     def __enter__(self) -> TrailAggregator:
         return self

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -90,6 +90,64 @@ class TestTrailAggregatorBasics:
             assert agg.summary()["total"] == 1
 
 
+class TestTrailAggregatorClose:
+    def test_close_closes_all_trails(self, tmp_path):
+        agg = TrailAggregator()
+        planner = ContextTrail(storage_path=str(tmp_path / "planner.db"))
+        executor = ContextTrail(storage_path=str(tmp_path / "executor.db"))
+        agg.add("planner", planner)
+        agg.add("executor", executor)
+
+        agg.close()
+
+        assert planner._backend._conn is None
+        assert executor._backend._conn is None
+
+    def test_close_closes_remaining_trails_when_one_raises(self, tmp_path):
+        agg = TrailAggregator()
+        planner = ContextTrail(storage_path=str(tmp_path / "planner.db"))
+        executor = ContextTrail(storage_path=str(tmp_path / "executor.db"))
+        agg.add("planner", planner)
+        agg.add("executor", executor)
+
+        def boom() -> None:
+            raise OSError("simulated disk full")
+
+        planner.close = boom  # type: ignore[method-assign]
+
+        with pytest.raises(OSError, match="simulated disk full"):
+            agg.close()
+
+        assert executor._backend._conn is None
+
+    def test_close_raises_first_error_and_logs_the_rest(self, tmp_path, caplog):
+        agg = TrailAggregator()
+        planner = ContextTrail(storage_path=str(tmp_path / "planner.db"))
+        executor = ContextTrail(storage_path=str(tmp_path / "executor.db"))
+        reviewer = ContextTrail(storage_path=str(tmp_path / "reviewer.db"))
+        agg.add("planner", planner)
+        agg.add("executor", executor)
+        agg.add("reviewer", reviewer)
+
+        def boom_planner() -> None:
+            raise OSError("planner disk full")
+
+        def boom_executor() -> None:
+            raise RuntimeError("executor already closed")
+
+        planner.close = boom_planner  # type: ignore[method-assign]
+        executor.close = boom_executor  # type: ignore[method-assign]
+
+        with (
+            caplog.at_level("WARNING", logger="provena.aggregator"),
+            pytest.raises(OSError, match="planner disk full"),
+        ):
+            agg.close()
+
+        assert "executor already closed" in caplog.text
+        assert reviewer._backend._conn is None
+
+
 class TestAggregatedSummary:
     def test_summary_totals(self, populated_aggregator):
         s = populated_aggregator.summary()


### PR DESCRIPTION
## What does this PR do?

`TrailAggregator.close()` looped over every registered trail calling `trail.close()` directly. If any trail's `close()` raised, the loop stopped immediately and every trail registered after it never got closed — leaking their backends, the same class of bug fixed for `ContextTrail.close()` in #144.

Implements the proposed fix from the issue: `close()` now attempts every trail regardless of earlier failures. The first exception is raised after all trails have had a chance to close; any additional exceptions are logged
(`provena.aggregator` logger) instead of being silently dropped, so a second or third failure isn't lost just because only one exception can be raised at a time.

Note for reviewers: with N failing trails, only the first failure is raised to the caller — the rest are only visible in logs, not catchable as exceptions. That matches the issue's proposed fix as written; happy to change to something like collecting all errors into a single raised exception if that's preferred instead.

## Checklist

- [x] Tests added/updated for the change
- [x] `ruff check src/ tests/` passes
- [x] `ruff format --check src/ tests/` passes
- [x] `mypy src/provena/` passes (1 pre-existing unrelated error on `main`, untouched by this change)
- [x] `pytest` passes with no failures (535 passed, 33 skipped — unrelated optional integrations)
- [x] CHANGELOG.md updated

## Related Issues

Fixes #177